### PR TITLE
feat: add user profile management and activation

### DIFF
--- a/backend/esign/settings.py
+++ b/backend/esign/settings.py
@@ -177,6 +177,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
 STATIC_URL = 'static/'
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field

--- a/backend/esign/urls.py
+++ b/backend/esign/urls.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from django.conf import settings
+from django.conf.urls.static import static
 from signature import views
 
 urlpatterns = [
@@ -10,5 +12,8 @@ urlpatterns = [
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/verify-token/', views.verify_token, name='verify_token'),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 

--- a/backend/signature/serializers.py
+++ b/backend/signature/serializers.py
@@ -19,19 +19,46 @@ import logging
 logger = logging.getLogger(__name__)
 
 User = get_user_model()
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = [
+            'username', 'email', 'first_name', 'last_name',
+            'birth_date', 'phone_number', 'gender', 'address', 'avatar'
+        ]
+        read_only_fields = ['username', 'email']
+
+
 class UserRegistrationSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True)
+    avatar = serializers.ImageField(required=False, allow_null=True)
 
     class Meta:
         model = User
-        fields = ['username', 'email', 'password']
+        fields = [
+            'username', 'email', 'password', 'first_name', 'last_name',
+            'birth_date', 'phone_number', 'gender', 'address', 'avatar'
+        ]
 
     def create(self, validated_data):
+        avatar = validated_data.pop('avatar', None)
         user = User.objects.create_user(
-            username=validated_data['username'],
-            email=validated_data['email'],
-            password=validated_data['password'],
+            username=validated_data.get('username'),
+            email=validated_data.get('email'),
+            password=validated_data.get('password'),
+            first_name=validated_data.get('first_name', ''),
+            last_name=validated_data.get('last_name', ''),
+            birth_date=validated_data.get('birth_date'),
+            phone_number=validated_data.get('phone_number', ''),
+            gender=validated_data.get('gender', ''),
+            address=validated_data.get('address', ''),
+            is_active=False,
         )
+        if avatar:
+            user.avatar = avatar
+            user.save()
         NotificationPreference.objects.create(user=user)
         return user
 

--- a/backend/signature/urls.py
+++ b/backend/signature/urls.py
@@ -7,17 +7,24 @@ from .views import (
     guest_envelope_view,
     serve_decrypted_pdf,
     register,
+    activate_account,
+    user_profile,
     password_reset_request,
     NotificationPreferenceViewSet,
 )
+
 router = DefaultRouter()
-router.register(r'envelopes',EnvelopeViewSet,basename='envelopes')
-router.register(r'prints',PrintQRCodeViewSet,basename='prints')
+router.register(r'envelopes', EnvelopeViewSet, basename='envelopes')
+router.register(r'prints', PrintQRCodeViewSet, basename='prints')
 router.register(r'notifications', NotificationPreferenceViewSet, basename='notifications')
+
 urlpatterns = [
     path('', include(router.urls)),
-     path('register/', register, name='register'),
+    path('register/', register, name='register'),
+    path('activate/<uidb64>/<token>/', activate_account, name='activate-account'),
+    path('profile/', user_profile, name='user-profile'),
     path('password-reset/', password_reset_request, name='password-reset'),
     path('envelopes/<int:pk>/guest/', guest_envelope_view, name='guest-envelope'),
     path('envelopes/<int:pk>/document/', serve_decrypted_pdf, name='serve-decrypted-pdf'),
 ]
+

--- a/backend/signature/views.py
+++ b/backend/signature/views.py
@@ -1,5 +1,11 @@
 from rest_framework import viewsets, status, permissions
-from rest_framework.decorators import action, api_view, permission_classes, authentication_classes
+from rest_framework.decorators import (
+    action,
+    api_view,
+    permission_classes,
+    authentication_classes,
+    parser_classes,
+)
 from django.utils.decorators import method_decorator
 from rest_framework.response import Response
 from django.utils import timezone
@@ -7,6 +13,7 @@ from django.db import transaction
 from django.http import Http404, StreamingHttpResponse, FileResponse
 from django.shortcuts import get_object_or_404
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.parsers import MultiPartParser, FormParser
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.clickjacking import xframe_options_exempt
 import jwt, logging, io, base64
@@ -16,6 +23,12 @@ from .tasks import send_signature_email
 from .otp import generate_otp, validate_otp, send_otp
 from .hsm import hsm_sign
 from django.conf import settings
+from django.core.mail import send_mail
+from django.urls import reverse
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import force_bytes, force_str
+from django.contrib.auth.tokens import default_token_generator
+from django.contrib.auth import get_user_model
 from .models import (
     Envelope,
     EnvelopeRecipient,
@@ -30,6 +43,7 @@ from .serializers import (
     SignatureDocumentSerializer,
     PrintQRCodeSerializer,
     UserRegistrationSerializer,
+    UserProfileSerializer,
     PasswordResetSerializer,
     NotificationPreferenceSerializer,
 )
@@ -68,14 +82,62 @@ tsa_client = HTTPTimeStamper(settings.FREETSA_URL)
 
 # Configure logging
 logger = logging.getLogger(__name__)
+User = get_user_model()
 
 @api_view(['POST'])
 @permission_classes([AllowAny])
+@parser_classes([MultiPartParser, FormParser])
 def register(request):
     serializer = UserRegistrationSerializer(data=request.data)
     if serializer.is_valid():
         user = serializer.save()
-        return Response({'id': user.id, 'username': user.username, 'email': user.email}, status=status.HTTP_201_CREATED)
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        token = default_token_generator.make_token(user)
+        activation_link = request.build_absolute_uri(
+            reverse('activate-account', kwargs={'uidb64': uid, 'token': token})
+        )
+        send_mail(
+            'Activation de compte',
+            f'Cliquez sur ce lien pour activer votre compte : {activation_link}',
+            settings.DEFAULT_FROM_EMAIL,
+            [user.email],
+            fail_silently=True,
+        )
+        return Response(
+            {'detail': 'Inscription réussie. Vérifiez votre e-mail pour activer votre compte.'},
+            status=status.HTTP_201_CREATED,
+        )
+    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def activate_account(request, uidb64, token):
+    try:
+        uid = force_str(urlsafe_base64_decode(uidb64))
+        user = User.objects.get(pk=uid)
+    except (User.DoesNotExist, ValueError, TypeError, OverflowError):
+        return Response({'error': 'Activation invalide'}, status=status.HTTP_400_BAD_REQUEST)
+
+    if default_token_generator.check_token(user, token):
+        user.is_active = True
+        user.save()
+        return Response({'detail': 'Compte activé avec succès'}, status=status.HTTP_200_OK)
+    return Response({'error': 'Token invalide'}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET', 'PUT'])
+@permission_classes([IsAuthenticated])
+@parser_classes([MultiPartParser, FormParser])
+def user_profile(request):
+    if request.method == 'GET':
+        serializer = UserProfileSerializer(request.user)
+        return Response(serializer.data)
+
+    serializer = UserProfileSerializer(request.user, data=request.data, partial=True)
+    if serializer.is_valid():
+        serializer.save()
+        return Response(serializer.data)
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
@@ -769,6 +831,11 @@ def verify_token(request):
                 'email': user.email,
                 'first_name': user.first_name,
                 'last_name': user.last_name,
+                'birth_date': user.birth_date,
+                'phone_number': user.phone_number,
+                'gender': user.gender,
+                'address': user.address,
+                'avatar': user.avatar.url if user.avatar else None,
             }
         }, status=status.HTTP_200_OK)
     except Exception as e:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import PasswordResetPage from './pages/PasswordResetPage';
 import NotificationSettings from './pages/NotificationSettings';
+import ProfilePage from './pages/ProfilePage';
 import SentEnvelopes from './components/SentEnvelopes';
 import CompletedEnvelopes from './components/CompletedEnvelopes';
 import ActionRequiredEnvelopes from './components/ActionRequiredEnvelopes';
@@ -70,7 +71,8 @@ const App = () => {
     <Route path="/signature/workflow/:id" element={<DocumentWorkflow />} />
     <Route path="/signature/envelopes/:id/sign" element={<DocumentSign />} />
     <Route path="/signature/sign/:id" element={<DocumentSign />} />
-       <Route path="/settings/notifications" element={<NotificationSettings />} />
+    <Route path="/settings/notifications" element={<NotificationSettings />} />
+    <Route path="/profile" element={<ProfilePage />} />
     {/* SignatureLayout et ses sous-pages */}
     <Route path="signature" element={<SignatureLayout />}>
       <Route path="envelopes/sent" element={<SentEnvelopes />} />

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from 'react';
+import { api, API_BASE_URL } from '../services/apiUtils';
+
+const ProfilePage = () => {
+  const [profile, setProfile] = useState({
+    username: '',
+    email: '',
+    first_name: '',
+    last_name: '',
+    birth_date: '',
+    phone_number: '',
+    gender: '',
+    address: '',
+    avatar: null,
+  });
+  const [avatarPreview, setAvatarPreview] = useState(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const res = await api.get('/api/signature/profile/');
+        setProfile(res.data);
+        if (res.data.avatar) {
+          setAvatarPreview(`${API_BASE_URL}${res.data.avatar}`);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setProfile((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    setProfile((prev) => ({ ...prev, avatar: file }));
+    if (file) {
+      setAvatarPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    Object.entries(profile).forEach(([key, value]) => {
+      if (value !== null && value !== undefined) {
+        formData.append(key, value);
+      }
+    });
+    try {
+      const res = await api.put('/api/signature/profile/', formData);
+      setMessage('Profil mis à jour');
+      if (res.data.avatar) {
+        setAvatarPreview(`${API_BASE_URL}${res.data.avatar}`);
+      }
+    } catch (err) {
+      setMessage("Erreur lors de la mise à jour");
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h2 className="text-2xl font-bold mb-4">Mon profil</h2>
+      {message && <div className="mb-4 text-center">{message}</div>}
+      <form onSubmit={handleSubmit} className="space-y-4" encType="multipart/form-data">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Nom d'utilisateur</label>
+          <input
+            type="text"
+            name="username"
+            value={profile.username || ''}
+            disabled
+            className="w-full border border-gray-300 rounded px-3 py-2 bg-gray-100"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Email</label>
+          <input
+            type="email"
+            name="email"
+            value={profile.email || ''}
+            disabled
+            className="w-full border border-gray-300 rounded px-3 py-2 bg-gray-100"
+          />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Prénom</label>
+            <input
+              type="text"
+              name="first_name"
+              value={profile.first_name || ''}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nom</label>
+            <input
+              type="text"
+              name="last_name"
+              value={profile.last_name || ''}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Date de naissance</label>
+          <input
+            type="date"
+            name="birth_date"
+            value={profile.birth_date || ''}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Téléphone</label>
+          <input
+            type="text"
+            name="phone_number"
+            value={profile.phone_number || ''}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Genre</label>
+          <select
+            name="gender"
+            value={profile.gender || ''}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          >
+            <option value="">Sélectionnez</option>
+            <option value="Homme">Homme</option>
+            <option value="Femme">Femme</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Adresse</label>
+          <textarea
+            name="address"
+            value={profile.address || ''}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Avatar</label>
+          {avatarPreview && (
+            <img
+              src={avatarPreview}
+              alt="Avatar"
+              className="h-16 w-16 rounded-full mb-2 object-cover"
+            />
+          )}
+          <input type="file" name="avatar" accept="image/*" onChange={handleFileChange} />
+        </div>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Enregistrer
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ProfilePage;
+

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -2,61 +2,175 @@ import React, { useState } from 'react';
 import { api } from '../services/apiUtils';
 
 const RegisterPage = () => {
-  const [username, setUsername] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [form, setForm] = useState({
+    username: '',
+    email: '',
+    password: '',
+    first_name: '',
+    last_name: '',
+    birth_date: '',
+    phone_number: '',
+    gender: '',
+    address: '',
+    avatar: null,
+  });
   const [message, setMessage] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleFileChange = (e) => {
+    setForm((prev) => ({ ...prev, avatar: e.target.files[0] }));
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setMessage('');
     try {
-      await api.post('/api/signature/register/', { username, email, password });
-      setMessage('Inscription réussie. Vous pouvez maintenant vous connecter.');
-      setUsername('');
-      setEmail('');
-      setPassword('');
+      const data = new FormData();
+      Object.entries(form).forEach(([key, value]) => {
+        if (value) data.append(key, value);
+      });
+      await api.post('/api/signature/register/', data);
+      setMessage('Inscription réussie. Vérifiez votre e-mail pour activer votre compte.');
+      setForm({
+        username: '',
+        email: '',
+        password: '',
+        first_name: '',
+        last_name: '',
+        birth_date: '',
+        phone_number: '',
+        gender: '',
+        address: '',
+        avatar: null,
+      });
     } catch (err) {
-      setMessage(err.response?.data?.error || 'Erreur lors de l\'inscription.');
+      setMessage(err.response?.data?.error || "Erreur lors de l'inscription.");
     }
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-full max-w-md">
+      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-full max-w-lg" encType="multipart/form-data">
         <h2 className="text-2xl font-bold mb-6 text-center">Inscription</h2>
         {message && <div className="mb-4 text-center">{message}</div>}
-        <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-700">Nom d'utilisateur</label>
-          <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nom d'utilisateur</label>
+            <input
+              type="text"
+              name="username"
+              value={form.username}
+              onChange={handleChange}
+              required
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Email</label>
+            <input
+              type="email"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              required
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Prénom</label>
+            <input
+              type="text"
+              name="first_name"
+              value={form.first_name}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nom</label>
+            <input
+              type="text"
+              name="last_name"
+              value={form.last_name}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Date de naissance</label>
+            <input
+              type="date"
+              name="birth_date"
+              value={form.birth_date}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Téléphone</label>
+            <input
+              type="text"
+              name="phone_number"
+              value={form.phone_number}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-gray-700">Genre</label>
+          <select
+            name="gender"
+            value={form.gender}
+            onChange={handleChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          >
+            <option value="">Sélectionnez</option>
+            <option value="Homme">Homme</option>
+            <option value="Femme">Femme</option>
+          </select>
+        </div>
+
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-gray-700">Adresse</label>
+          <textarea
+            name="address"
+            value={form.address}
+            onChange={handleChange}
             className="w-full border border-gray-300 rounded px-3 py-2"
           />
         </div>
-        <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-700">Email</label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full border border-gray-300 rounded px-3 py-2"
-          />
+
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-gray-700">Avatar</label>
+          <input type="file" name="avatar" onChange={handleFileChange} accept="image/*" />
         </div>
-        <div className="mb-6">
+
+        <div className="mt-4">
           <label className="block text-sm font-medium text-gray-700">Mot de passe</label>
           <input
             type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            name="password"
+            value={form.password}
+            onChange={handleChange}
             required
             className="w-full border border-gray-300 rounded px-3 py-2"
           />
         </div>
-        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
+
+        <button type="submit" className="w-full mt-6 bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
           S'inscrire
         </button>
       </form>
@@ -65,3 +179,4 @@ const RegisterPage = () => {
 };
 
 export default RegisterPage;
+


### PR DESCRIPTION
## Summary
- add full profile serializer and registration fields with email activation
- create profile API and React page with editing
- configure media serving and expose profile route

## Testing
- `python backend/manage.py test` *(fails: ImproperlyConfigured: Set the DJANGO_SECRET_KEY environment variable)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1bd2d97c833383a47164793234ef