### PR TITLE
Handle recipient filtering and expose envelope status helpers

### DIFF
--- a/frontend/src/pages/DashboardSignature.js
+++ b/frontend/src/pages/DashboardSignature.js
@@ -42,11 +42,13 @@ const DashboardSignature = () => {
   useEffect(() => {
     const loadData = async () => {
       try {
-        const all = await signatureService.getEnvelopes();
-        const drafts = all.filter(e => e.status === 'draft');
-        const sent = all.filter(e => e.status === 'sent');
-        const completed = all.filter(e => e.status === 'completed');
-        const actionReq = await signatureService.getActionRequiredEnvelopes();
+        const [drafts, sent, completed, actionReq] = await Promise.all([
+          signatureService.getEnvelopes({ status: 'draft' }),
+          signatureService.getEnvelopes({ status: 'sent' }),
+          signatureService.getCompletedEnvelopes(),
+          signatureService.getReceivedEnvelopes()
+        ]);
+        const all = [...drafts, ...sent, ...completed];
 
         const now = new Date();
         const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);

--- a/frontend/src/services/signatureService.js
+++ b/frontend/src/services/signatureService.js
@@ -15,6 +15,22 @@ export default {
       .get(`${BASE}/envelopes/`, { params: { status: 'action_required' } })
       .then(res => res.data),
 
+  /**
+   * Récupère les enveloppes dont le statut est 'action_required' (documents à signer).
+   */
+  getReceivedEnvelopes: () =>
+    api
+      .get(`${BASE}/envelopes/`, { params: { status: 'action_required' } })
+      .then(res => res.data),
+
+  /**
+   * Récupère les enveloppes complétées pour l'utilisateur.
+   */
+  getCompletedEnvelopes: () =>
+    api
+      .get(`${BASE}/envelopes/`, { params: { status: 'completed' } })
+      .then(res => res.data),
+
   getEnvelope: (id, config = {}) =>
     api.get(`${BASE}/envelopes/${id}/`, config).then(res => res.data),
 


### PR DESCRIPTION
## Summary
- include recipients identified only by email in envelope queries
- add front-end helpers for completed and received envelopes
- update dashboard to use new helper methods when collecting stats

## Testing
- `DJANGO_SECRET_KEY=foo FILE_ENCRYPTION_KEY=MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA= python manage.py test` *(fails: Set the POSTGRES_DB environment variable)*
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a320915e08333bff3ebe7b275c556