### PR TITLE
feat: add envelope sent page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import DocumentDetail from './pages/DocumentDetail';
 import DocumentSign from './pages/DocumentSign';
 import DocumentUpload from './pages/DocumentUpload';
 import DocumentWorkflow from './pages/DocumentWorkflow';
+import EnvelopeSent from './pages/EnvelopeSent';
 import SignatureConfirmation from './pages/SignatureConfirmation';
 import SignatureLayout from './pages/SignatureLayout';
 import LoginPage from './pages/LoginPage';
@@ -69,6 +70,7 @@ const App = () => {
     <Route path="/signature/upload" element={<DocumentUpload />} />
     <Route path="/signature/detail/:id" element={<DocumentDetail />} />
     <Route path="/signature/workflow/:id" element={<DocumentWorkflow />} />
+    <Route path="/signature/sent/:id" element={<EnvelopeSent />} />
     <Route path="/signature/envelopes/:id/sign" element={<DocumentSign />} />
     <Route path="/signature/sign/:id" element={<DocumentSign />} />
     <Route path="/settings/notifications" element={<NotificationSettings />} />

--- a/frontend/src/pages/DocumentWorkflow.js
+++ b/frontend/src/pages/DocumentWorkflow.js
@@ -116,7 +116,7 @@ export default function DocumentWorkflow() {
       });
       await signatureService.sendEnvelope(id);
       toast.success('Enveloppe envoyée');
-      navigate('/signature/list');
+      navigate(`/signature/sent/${id}`);
     } catch {
       toast.error("Échec de l'envoi");
     }

--- a/frontend/src/pages/EnvelopeSent.js
+++ b/frontend/src/pages/EnvelopeSent.js
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import signatureService from '../services/signatureService';
+
+export default function EnvelopeSent() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [envelope, setEnvelope] = useState(null);
+
+  useEffect(() => {
+    signatureService
+      .getEnvelope(id)
+      .then(data => setEnvelope(data))
+      .catch(() => setEnvelope(null));
+  }, [id]);
+
+  if (!envelope) {
+    return <div className="p-6">Chargement...</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">{envelope.title}</h1>
+
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">Destinataires</h2>
+        <ul className="list-disc list-inside space-y-1">
+          {envelope.recipients?.map(r => (
+            <li key={r.id}>{r.full_name} ({r.email})</li>
+          ))}
+        </ul>
+      </div>
+
+      {envelope.deadline_at && (
+        <p className="mb-6">
+          <strong>Date limite :</strong>{' '}
+          {new Date(envelope.deadline_at).toLocaleDateString('fr-FR')}
+        </p>
+      )}
+
+      <div className="flex space-x-4">
+        <button
+          onClick={() => navigate(`/signature/detail/${id}`)}
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        >
+          Voir le document
+        </button>
+        <button
+          onClick={() => navigate('/dashboard')}
+          className="bg-gray-300 text-gray-800 px-4 py-2 rounded hover:bg-gray-400"
+        >
+          Retour au tableau de bord
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add envelope sent confirmation page and routing
- redirect workflow to confirmation screen after sending

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: pixman-1 missing for canvas build)*

------
https://chatgpt.com/codex/tasks/task_e_689a33c4c9988333a32f307ae5dca222