### PR TITLE
Limit OTP attempts and switch default language to French

### DIFF
--- a/backend/esign/settings.py
+++ b/backend/esign/settings.py
@@ -164,7 +164,7 @@ FRONT_BASE_URL = env.str("FRONT_BASE_URL")
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'fr'
 
 TIME_ZONE = 'UTC'
 

--- a/backend/signature/views/envelope.py
+++ b/backend/signature/views/envelope.py
@@ -327,7 +327,12 @@ class EnvelopeViewSet(viewsets.ModelViewSet):
                 return Response({'error': "Les destinataires précédents doivent signer d'abord"}, status=status.HTTP_400_BAD_REQUEST)
 
         otp = request.data.get('otp')
-        if not otp or not validate_otp(recipient, otp):
+        if not otp:
+            return Response({'error': 'OTP invalide'}, status=status.HTTP_400_BAD_REQUEST)
+        is_valid, blocked = validate_otp(recipient, otp)
+        if blocked:
+            return Response({'error': 'Trop de tentatives, OTP verrouillé'}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+        if not is_valid:
             return Response({'error': 'OTP invalide'}, status=status.HTTP_400_BAD_REQUEST)
 
         return Response({'status': 'otp_verified'}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- prevent OTP brute force with a max attempt limit
- set Django's default language code to French

## Testing
- `python manage.py test` *(fails: ImproperlyConfigured: Set the EMAIL_HOST_USER environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689a4db3c9008333ba878e9a332a0b68