### PR TITLE
feat: secure tokens and add audit logging

### DIFF
--- a/backend/esign/settings.py
+++ b/backend/esign/settings.py
@@ -126,7 +126,7 @@ DATABASES = {
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'signature.authentication.CookieJWTAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',

--- a/backend/esign/urls.py
+++ b/backend/esign/urls.py
@@ -1,17 +1,22 @@
 from django.contrib import admin
 from django.urls import path, include
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from django.conf import settings
 from django.conf.urls.static import static
 from signature import views
-from signature.views.auth import verify_token
+from signature.views.auth import (
+    verify_token,
+    CookieTokenObtainPairView,
+    CookieTokenRefreshView,
+    logout,
+)
 
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/signature/', include('signature.urls')),
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/token/', CookieTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/refresh/', CookieTokenRefreshView.as_view(), name='token_refresh'),
+    path('api/logout/', logout, name='logout'),
     path('api/verify-token/', verify_token, name='verify_token'),
 ]
 

--- a/backend/signature/admin.py
+++ b/backend/signature/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import AuditLog
+
+
+@admin.register(AuditLog)
+class AuditLogAdmin(admin.ModelAdmin):
+    list_display = ('action', 'user', 'envelope', 'ip_address', 'created_at')
+    search_fields = ('action', 'user__username', 'envelope__title', 'ip_address')
+    list_filter = ('action', 'created_at')

--- a/backend/signature/authentication.py
+++ b/backend/signature/authentication.py
@@ -1,0 +1,15 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """JWT authentication that also reads tokens from HttpOnly cookies."""
+
+    def authenticate(self, request):
+        header = self.get_header(request)
+        if header is not None:
+            raw_token = self.get_raw_token(header)
+        else:
+            raw_token = request.COOKIES.get('access_token')
+        if raw_token is None:
+            return None
+        validated_token = self.get_validated_token(raw_token)
+        return self.get_user(validated_token), validated_token

--- a/backend/signature/migrations/0004_auditlog.py
+++ b/backend/signature/migrations/0004_auditlog.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signature', '0003_notificationpreference'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AuditLog',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('action', models.CharField(max_length=255)),
+                ('details', models.JSONField(blank=True, default=dict)),
+                ('ip_address', models.GenericIPAddressField(blank=True, null=True)),
+                ('user_agent', models.CharField(blank=True, max_length=500)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('envelope', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='signature.envelope')),
+                ('user', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/backend/signature/models.py
+++ b/backend/signature/models.py
@@ -269,3 +269,28 @@ class NotificationPreference(models.Model):
 
     def __str__(self):
         return f"Notifications for {self.user.username}"
+
+
+class AuditLog(models.Model):
+    """Simple audit trail for user actions."""
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+    envelope = models.ForeignKey(
+        'Envelope',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+    action = models.CharField(max_length=255)
+    details = models.JSONField(default=dict, blank=True)
+    ip_address = models.GenericIPAddressField(null=True, blank=True)
+    user_agent = models.CharField(max_length=500, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.action} by {self.user} on {self.created_at}"

--- a/backend/signature/views/envelope.py
+++ b/backend/signature/views/envelope.py
@@ -28,6 +28,7 @@ from ..models import (
     EnvelopeRecipient,
     SignatureDocument,
     PrintQRCode,
+    AuditLog,
 )
 from ..serializers import (
     EnvelopeSerializer,
@@ -548,6 +549,15 @@ class EnvelopeViewSet(viewsets.ModelViewSet):
                 signed_fields=signed_fields,
                 ip_address=self.request.META.get('REMOTE_ADDR'),
                 user_agent=self.request.META.get('HTTP_USER_AGENT', '')
+            )
+
+            AuditLog.objects.create(
+                user=self.request.user if self.request.user.is_authenticated else None,
+                envelope=recipient.envelope,
+                action='document_signed',
+                details={'recipient_id': recipient.id, 'signature_id': sig_doc.id},
+                ip_address=self.request.META.get('REMOTE_ADDR'),
+                user_agent=self.request.META.get('HTTP_USER_AGENT', ''),
             )
 
             # 3. Fusionner image+PDF


### PR DESCRIPTION
## Summary
- move JWT authentication to HttpOnly cookies and expose custom login, refresh and logout endpoints
- remove localStorage tokens and use cookie-based auth on the frontend
- introduce audit log model to record signing events

## Testing
- `python manage.py test` *(fails: Set the DJANGO_SECRET_KEY environment variable)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*
- `npm install` *(fails: node-pre-gyp ERR! build error; missing pixman-1)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a595f4fc48333a9eb07d5b5033212