### PR TITLE
feat: add webhook and multi-document support

### DIFF
--- a/backend/signature/migrations/0005_envelopedocument_webhookendpoint.py
+++ b/backend/signature/migrations/0005_envelopedocument_webhookendpoint.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import signature.storages
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signature', '0004_auditlog'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EnvelopeDocument',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('file', models.FileField(storage=signature.storages.EncryptedFileSystemStorage(), upload_to='signature/documents/')),
+                ('name', models.CharField(blank=True, max_length=255)),
+                ('file_type', models.CharField(blank=True, max_length=50)),
+                ('file_size', models.PositiveIntegerField(blank=True, null=True)),
+                ('hash_original', models.CharField(blank=True, max_length=64)),
+                ('version', models.PositiveIntegerField(default=1)),
+                ('envelope', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='documents', to='signature.envelope')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='WebhookEndpoint',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('url', models.URLField()),
+                ('event', models.CharField(choices=[('envelope_sent', 'Envelope sent'), ('envelope_signed', 'Envelope signed'), ('envelope_cancelled', 'Envelope cancelled')], max_length=50)),
+                ('secret', models.CharField(blank=True, max_length=255)),
+                ('active', models.BooleanField(default=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='envelope',
+            name='document_file',
+            field=models.FileField(blank=True, null=True, storage=signature.storages.EncryptedFileSystemStorage(), upload_to='signature/documents/'),
+        ),
+    ]

--- a/backend/signature/webhooks.py
+++ b/backend/signature/webhooks.py
@@ -1,0 +1,29 @@
+import logging
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def trigger_webhooks(event, envelope):
+    """Send webhook notifications for a given event."""
+    from .models import WebhookEndpoint  # local import to avoid circular
+
+    endpoints = WebhookEndpoint.objects.filter(event=event, active=True)
+    if not endpoints.exists():
+        return
+
+    payload = {
+        "event": event,
+        "envelope_id": envelope.id,
+        "status": envelope.status,
+        "title": envelope.title,
+    }
+    headers = {"Content-Type": "application/json"}
+    for endpoint in endpoints:
+        try:
+            if endpoint.secret:
+                headers["X-Hub-Signature"] = endpoint.secret
+            requests.post(endpoint.url, json=payload, timeout=5, headers=headers)
+        except Exception as exc:
+            logger.error(f"Webhook call failed for {endpoint.url}: {exc}")

--- a/frontend/src/pages/DocumentSign.js
+++ b/frontend/src/pages/DocumentSign.js
@@ -31,6 +31,7 @@ const DocumentSign = () => {
   const [otpVerified, setOtpVerified] = useState(false);
   const [sendingOtp, setSendingOtp] = useState(false);
   const [verifyingOtp, setVerifyingOtp] = useState(false);
+  const [otpError, setOtpError] = useState('');
 
   // PDF rendering
   const [numPages, setNumPages] = useState(0);
@@ -119,11 +120,14 @@ const DocumentSign = () => {
     try {
       await signatureService.verifyOtp(id, otp, token);
       setOtpVerified(true);
+      setOtpError('');
       toast.success('OTP vérifié');
       await fetchPdfBlob(envelope.document_url);
     } catch (e) {
       console.error(e);
-      toast.error(e.response?.data?.error || 'OTP invalide');
+      const msg = e.response?.data?.error || 'OTP invalide';
+      setOtpError(msg);
+      toast.error(msg);
     } finally {
       setVerifyingOtp(false);
     }
@@ -228,6 +232,7 @@ const DocumentSign = () => {
               placeholder="Entrez le code OTP"
               className="w-full border p-2 rounded mb-2"
             />
+            {otpError && <p className="text-red-600 text-sm mb-2">{otpError}</p>}
             <button
               onClick={handleVerifyOtp}
               disabled={verifyingOtp}

--- a/frontend/src/pages/DocumentUpload.js
+++ b/frontend/src/pages/DocumentUpload.js
@@ -5,41 +5,41 @@ import { toast } from 'react-toastify';
 import { FiUpload, FiFileText } from 'react-icons/fi';
 
 const DocumentUpload = () => {
-  const [file, setFile] = useState(null);
+  const [files, setFiles] = useState([]);
   const [title, setTitle] = useState('');
   const navigate = useNavigate();
 
   const handleFileChange = (e) => {
-    const selectedFile = e.target.files[0];
-    if (selectedFile) {
-      if (selectedFile.size === 0) {
+    const selectedFiles = Array.from(e.target.files);
+    const valid = [];
+    selectedFiles.forEach((f) => {
+      if (f.size === 0) {
         toast.error('Le fichier sélectionné est vide');
         return;
       }
-      if (selectedFile.size > 10 * 1024 * 1024) {
+      if (f.size > 10 * 1024 * 1024) {
         toast.error('Le fichier est trop volumineux (max 10MB)');
         return;
       }
-      if (!selectedFile.name.toLowerCase().endsWith('.pdf')) {
+      if (!f.name.toLowerCase().endsWith('.pdf')) {
         toast.error('Seuls les fichiers PDF sont autorisés');
         return;
       }
-      setFile(selectedFile);
-    } else {
-      setFile(null);
-    }
+      valid.push(f);
+    });
+    setFiles(valid);
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!file || !title) {
-      toast.error('Veuillez fournir un titre et un fichier valide');
+    if (!files.length || !title) {
+      toast.error('Veuillez fournir un titre et au moins un fichier valide');
       return;
     }
 
     const formData = new FormData();
     formData.append('title', title);
-    formData.append('document_file', file);
+    files.forEach((f) => formData.append('files', f));
     formData.append('status', 'draft');
 
     try {
@@ -73,30 +73,31 @@ const DocumentUpload = () => {
             />
           </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Fichier (PDF uniquement)</label>
-            <input
-              type="file"
-              onChange={handleFileChange}
-              accept=".pdf"
-              className="w-full border border-gray-300 px-4 py-2 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 bg-gray-50"
-              required
-            />
-            {file && (
-              <p className="mt-2 text-sm text-green-600">
-                Fichier sélectionné : <strong>{file.name}</strong>
-              </p>
-            )}
-          </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Fichier (PDF uniquement)</label>
+              <input
+                type="file"
+                onChange={handleFileChange}
+                accept=".pdf"
+                multiple
+                className="w-full border border-gray-300 px-4 py-2 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 bg-gray-50"
+                required
+              />
+              {files.length > 0 && (
+                <p className="mt-2 text-sm text-green-600">
+                  {files.length} fichier(s) sélectionné(s)
+                </p>
+              )}
+            </div>
 
-          <button
-            type="submit"
-            disabled={!file || !title}
-            className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-5 py-2 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <FiUpload />
-            Téléverser
-          </button>
+            <button
+              type="submit"
+              disabled={!files.length || !title}
+              className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-5 py-2 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <FiUpload />
+              Téléverser
+            </button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add webhook triggering on envelope status changes
- support multiple documents per envelope
- show OTP retry limit message on signing page

## Testing
- `python manage.py test` *(fails: Set the FRONT_BASE_URL environment variable)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a61e1658083338b244f8e576a4d34