### PR TITLE
feat: add password reset confirmation flow

### DIFF
--- a/backend/signature/serializers.py
+++ b/backend/signature/serializers.py
@@ -4,6 +4,8 @@ from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import send_mail
 from django.conf import settings
 from django.db import transaction
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
 
 from .models import (SavedSignature, FieldTemplate, BatchSignJob, BatchSignItem,
     Envelope,EnvelopeRecipient,SigningField,SignatureDocument,PrintQRCode,
@@ -85,7 +87,8 @@ class PasswordResetSerializer(serializers.Serializer):
         email = self.validated_data['email']
         user = User.objects.get(email=email)
         token = default_token_generator.make_token(user)
-        reset_link = request.build_absolute_uri(f"/reset-password/{user.pk}/{token}/")
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        reset_link = request.build_absolute_uri(f"/reset-password/{uid}/{token}/")
         send_mail(
             'Réinitialisation de mot de passe',
             f'Utilisez ce lien pour réinitialiser votre mot de passe : {reset_link}',

--- a/backend/signature/urls.py
+++ b/backend/signature/urls.py
@@ -12,6 +12,7 @@ from .views.auth import (
     activate_account,
     user_profile,
     password_reset_request,
+    password_reset_confirm,
 )
 from .views.notification import NotificationPreferenceViewSet
 from .views.batch import SelfSignView, BatchSignCreateView, BatchSignJobViewSet
@@ -30,6 +31,7 @@ urlpatterns = [
     path('activate/<uidb64>/<token>/', activate_account, name='activate-account'),
     path('profile/', user_profile, name='user-profile'),
     path('password-reset/', password_reset_request, name='password-reset'),
+    path('password-reset/<uidb64>/<token>/', password_reset_confirm, name='password-reset-confirm'),
     path('envelopes/<int:pk>/guest/', guest_envelope_view, name='guest-envelope'),
     path('envelopes/<int:pk>/document/', serve_decrypted_pdf, name='serve-decrypted-pdf'),
 ]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import SignatureLayout from './pages/SignatureLayout';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import PasswordResetPage from './pages/PasswordResetPage';
+import PasswordResetConfirmPage from './pages/PasswordResetConfirmPage';
 import NotificationSettings from './pages/NotificationSettings';
 import ProfilePage from './pages/ProfilePage';
 import SelfSignWizard from './pages/SelfSignWizard';
@@ -55,11 +56,12 @@ const App = () => {
       {/* ROUTES PUBLIQUES - À PLACER EN PREMIER ET DANS LE BON ORDRE */}
       
       {/* LOGIN */}
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/register" element={<RegisterPage />} />
-      <Route path="/password-reset" element={<PasswordResetPage />} />
-      {/* Signature invitée avec token - ROUTE PUBLIQUE */}
-      <Route path="/sign/:id" element={<DocumentSign />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/password-reset" element={<PasswordResetPage />} />
+        <Route path="/reset-password/:uid/:token" element={<PasswordResetConfirmPage />} />
+        {/* Signature invitée avec token - ROUTE PUBLIQUE */}
+        <Route path="/sign/:id" element={<DocumentSign />} />
       
       {/* Page de confirmation - PUBLIQUE */}
       <Route path="/signature/success" element={<SignatureConfirmation />} />

--- a/frontend/src/pages/PasswordResetConfirmPage.js
+++ b/frontend/src/pages/PasswordResetConfirmPage.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { api } from '../services/apiUtils';
+
+const PasswordResetConfirmPage = () => {
+  const { uid, token } = useParams();
+  const navigate = useNavigate();
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage('');
+    try {
+      await api.post(`/api/signature/password-reset/${uid}/${token}/`, {
+        password,
+        confirm_password: confirmPassword,
+      });
+      setMessage('Mot de passe réinitialisé avec succès. Vous pouvez maintenant vous connecter.');
+      setPassword('');
+      setConfirmPassword('');
+      setTimeout(() => navigate('/login'), 2000);
+    } catch (err) {
+      setMessage("Erreur lors de la réinitialisation du mot de passe.");
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-full max-w-md">
+        <h2 className="text-2xl font-bold mb-6 text-center">Nouveau mot de passe</h2>
+        {message && <div className="mb-4 text-center">{message}</div>}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700">Mot de passe</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          />
+        </div>
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-gray-700">Confirmer le mot de passe</label>
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          />
+        </div>
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
+          Réinitialiser
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default PasswordResetConfirmPage;


### PR DESCRIPTION
## Summary
- handle password reset confirmations in backend
- expose password reset confirm endpoint in URLs
- add React page and route for setting a new password

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2401bb8448333a91713d6926b81a3