### PR TITLE
feat: add password change endpoint

### DIFF
--- a/backend/signature/serializers.py
+++ b/backend/signature/serializers.py
@@ -95,6 +95,29 @@ class PasswordResetSerializer(serializers.Serializer):
         )
 
 
+class ChangePasswordSerializer(serializers.Serializer):
+    old_password = serializers.CharField(write_only=True)
+    new_password = serializers.CharField(write_only=True)
+
+    def validate_old_password(self, value):
+        user = self.context['request'].user
+        if not user.check_password(value):
+            raise serializers.ValidationError("Ancien mot de passe incorrect")
+        return value
+
+    def validate_new_password(self, value):
+        from django.contrib.auth.password_validation import validate_password
+
+        validate_password(value, self.context['request'].user)
+        return value
+
+    def save(self, **kwargs):
+        user = self.context['request'].user
+        user.set_password(self.validated_data['new_password'])
+        user.save()
+        return user
+
+
 class NotificationPreferenceSerializer(serializers.ModelSerializer):
     class Meta:
         model = NotificationPreference

--- a/backend/signature/urls.py
+++ b/backend/signature/urls.py
@@ -12,6 +12,7 @@ from .views.auth import (
     activate_account,
     user_profile,
     password_reset_request,
+    change_password,
 )
 from .views.notification import NotificationPreferenceViewSet
 from .views.batch import SelfSignView, BatchSignCreateView, BatchSignJobViewSet
@@ -30,6 +31,7 @@ urlpatterns = [
     path('activate/<uidb64>/<token>/', activate_account, name='activate-account'),
     path('profile/', user_profile, name='user-profile'),
     path('password-reset/', password_reset_request, name='password-reset'),
+    path('change-password/', change_password, name='change-password'),
     path('envelopes/<int:pk>/guest/', guest_envelope_view, name='guest-envelope'),
     path('envelopes/<int:pk>/document/', serve_decrypted_pdf, name='serve-decrypted-pdf'),
 ]

--- a/backend/signature/views/auth.py
+++ b/backend/signature/views/auth.py
@@ -13,7 +13,12 @@ from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth import get_user_model
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from ..serializers import UserRegistrationSerializer, UserProfileSerializer, PasswordResetSerializer
+from ..serializers import (
+    UserRegistrationSerializer,
+    UserProfileSerializer,
+    PasswordResetSerializer,
+    ChangePasswordSerializer,
+)
 
 User = get_user_model()
 
@@ -122,6 +127,16 @@ def password_reset_request(request):
     if serializer.is_valid():
         serializer.save()
         return Response({'detail': 'Email de réinitialisation envoyé'}, status=status.HTTP_200_OK)
+    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def change_password(request):
+    serializer = ChangePasswordSerializer(data=request.data, context={'request': request})
+    if serializer.is_valid():
+        serializer.save()
+        return Response({'detail': 'Mot de passe mis à jour'}, status=status.HTTP_200_OK)
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(['GET'])

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -15,6 +15,11 @@ const ProfilePage = () => {
   });
   const [avatarPreview, setAvatarPreview] = useState(null);
   const [message, setMessage] = useState('');
+  const [passwordData, setPasswordData] = useState({
+    old_password: '',
+    new_password: '',
+  });
+  const [pwdMessage, setPwdMessage] = useState('');
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -41,6 +46,22 @@ const ProfilePage = () => {
     setProfile((prev) => ({ ...prev, avatar: file }));
     if (file) {
       setAvatarPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const handlePasswordChange = (e) => {
+    const { name, value } = e.target;
+    setPasswordData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handlePasswordSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await api.post('/api/signature/change-password/', passwordData);
+      setPwdMessage('Mot de passe mis à jour');
+      setPasswordData({ old_password: '', new_password: '' });
+    } catch (err) {
+      setPwdMessage('Erreur lors du changement de mot de passe');
     }
   };
 
@@ -168,6 +189,37 @@ const ProfilePage = () => {
           className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
         >
           Enregistrer
+        </button>
+      </form>
+      <hr className="my-6" />
+      <h3 className="text-xl font-bold mb-4">Changer le mot de passe</h3>
+      {pwdMessage && <div className="mb-4 text-center">{pwdMessage}</div>}
+      <form onSubmit={handlePasswordSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Ancien mot de passe</label>
+          <input
+            type="password"
+            name="old_password"
+            value={passwordData.old_password}
+            onChange={handlePasswordChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700">Nouveau mot de passe</label>
+          <input
+            type="password"
+            name="new_password"
+            value={passwordData.new_password}
+            onChange={handlePasswordChange}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+          />
+        </div>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Modifier le mot de passe
         </button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- allow users to change password via new API endpoint
- add serializer for old/new password validation
- expose change-password endpoint and frontend form

## Testing
- `pytest` (fails: ImproperlyConfigured; settings not configured)
- `CI=true npm test` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_68a240706abc8333bcfdc2c423f4d0bf