### PR TITLE
Refactor envelope views into dedicated modules

### DIFF
--- a/backend/signature/urls.py
+++ b/backend/signature/urls.py
@@ -1,8 +1,8 @@
 # signature/urls.py
 from rest_framework.routers import DefaultRouter
 from django.urls import path, include
-from .views.envelope import (EnvelopeViewSet,PrintQRCodeViewSet,guest_envelope_view,serve_decrypted_pdf)
-from .views.auth import (register,activate_account,user_profile,password_reset_request,change_password,)
+from .views.recipient_view import EnvelopeViewSet, PrintQRCodeViewSet
+from .views.guest_view import guest_envelope_view, serve_decrypted_pdf
 from .views.notification import NotificationPreferenceViewSet
 from .views.batch import SelfSignView, BatchSignCreateView, BatchSignJobViewSet
 from .views.saved_signature import SavedSignatureViewSet

--- a/backend/signature/views/guest_view.py
+++ b/backend/signature/views/guest_view.py
@@ -1,0 +1,84 @@
+from rest_framework.decorators import api_view, permission_classes, authentication_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework import status
+from django.shortcuts import get_object_or_404
+from django.views.decorators.clickjacking import xframe_options_exempt
+from ..models import Envelope, EnvelopeRecipient, SignatureDocument
+from ..serializers import EnvelopeSerializer
+from .recipient_view import EnvelopeViewSet
+from .helpers import verify_guest_token, safe_filename, serve_pdf
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def guest_envelope_view(request, pk):
+    envelope = get_object_or_404(Envelope, pk=pk)
+
+    token = (
+        request.GET.get('token')
+        or request.POST.get('token')
+        or request.headers.get('X-Signature-Token')
+        or (request.headers.get('Authorization', '').replace('Bearer ', '')
+            if request.headers.get('Authorization') else '')
+    )
+
+    payload = verify_guest_token(envelope, token)
+    if payload is None:
+        return Response({'error': 'Token invalide ou manquant'}, status=status.HTTP_403_FORBIDDEN)
+
+    recipient_id = payload.get('recipient_id')
+    try:
+        recipient = EnvelopeRecipient.objects.get(envelope=envelope, id=recipient_id)
+    except EnvelopeRecipient.DoesNotExist:
+        return Response({'error': 'Destinataire non valide'}, status=status.HTTP_403_FORBIDDEN)
+
+    data = EnvelopeSerializer(envelope).data
+    fields = EnvelopeViewSet()._build_fields_payload(envelope, current_recipient_id=recipient.id)
+
+    from django.urls import reverse
+    doc_path = reverse('signature-serve-decrypted-pdf', kwargs={'pk': envelope.id})
+    document_url = request.build_absolute_uri(f"{doc_path}?token={token}")
+
+    data.update({
+        'fields': fields,
+        'recipient_id': recipient.id,
+        'recipient_full_name': recipient.full_name,
+        'document_url': document_url,
+    })
+    return Response(data)
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+@authentication_classes([])
+@xframe_options_exempt
+def serve_decrypted_pdf(request, pk: int):
+    envelope = get_object_or_404(Envelope, pk=pk)
+
+    token = (
+        request.GET.get("token")
+        or request.headers.get("X-Signature-Token")
+        or (request.headers.get("Authorization", "").replace("Bearer ", "")
+            if request.headers.get("Authorization") else "")
+    )
+
+    payload = verify_guest_token(envelope, token)
+    if payload is None:
+        return Response({"error": "Token invalide ou manquant"}, status=status.HTTP_403_FORBIDDEN)
+
+    if envelope.status == 'completed':
+        sig_doc = (
+            SignatureDocument.objects
+            .filter(envelope=envelope, signed_file__isnull=False)
+            .order_by('-signed_at')
+            .first()
+        )
+        if sig_doc and sig_doc.signed_file:
+            filename = safe_filename(envelope.title or "document")
+            return serve_pdf(sig_doc.signed_file, filename, inline=True)
+
+    doc = envelope.document_file or (envelope.documents.first().file if envelope.documents.exists() else None)
+    if not doc:
+        return Response({"error": "Pas de document disponible"}, status=status.HTTP_404_NOT_FOUND)
+
+    filename = safe_filename(envelope.title or "document")
+    return serve_pdf(doc, filename, inline=True)

--- a/backend/signature/views/helpers.py
+++ b/backend/signature/views/helpers.py
@@ -1,0 +1,59 @@
+import logging
+from django.conf import settings
+import jwt
+from jwt import InvalidTokenError, ExpiredSignatureError
+from django.http import HttpResponse
+
+logger = logging.getLogger(__name__)
+
+def clean_b64(data: str | None) -> str | None:
+    """Accepte 'data:image/...;base64,AAAA' ou déjà 'AAAA', renvoie le base64 pur ou None."""
+    if not data:
+        return None
+    if isinstance(data, str) and data.startswith('data:image'):
+        return data.split(',', 1)[1]
+    return data
+
+def verify_guest_token(envelope, token):
+    """Retourne le payload (dict) si le token invité est valide et correspond à l'enveloppe, sinon None."""
+    if not token:
+        return None
+    secret = getattr(settings, "SIGNATURE_JWT_SECRET", settings.SECRET_KEY)
+    try:
+        payload = jwt.decode(token, secret, algorithms=["HS256"])
+        if payload.get("env_id") != envelope.id:
+            return None
+        return payload
+    except (ExpiredSignatureError, InvalidTokenError):
+        return None
+
+def safe_filename(name: str) -> str:
+    base = (name or "document").replace('"', "").strip() or "document"
+    if not base.lower().endswith(".pdf"):
+        base += ".pdf"
+    return base
+
+def serve_pdf(file_field, filename: str, inline: bool = True) -> HttpResponse:
+    try:
+        fh = file_field.storage.open(file_field.name, "rb")
+        data = fh.read()
+        fh.close()
+    except Exception:
+        logger.exception("Erreur lors du service du PDF")
+        raise
+
+    resp = HttpResponse(data, content_type="application/pdf")
+    disp = "inline" if inline else "attachment"
+    safe_name = safe_filename(filename)
+    resp["Content-Disposition"] = f'{disp}; filename="{safe_name}"; filename*=UTF-8\'\'{safe_name}'
+
+    resp["X-Frame-Options"] = "SAMEORIGIN"
+    frame_ancestors = getattr(settings, "SIGNATURE_FRAME_ANCESTORS", "*")
+    resp["Content-Security-Policy"] = (
+        f"frame-ancestors {frame_ancestors}; sandbox allow-scripts allow-forms allow-same-origin"
+    )
+
+    resp["Cache-Control"] = "no-store"
+    resp["Pragma"] = "no-cache"
+    resp["Expires"] = "0"
+    return resp


### PR DESCRIPTION
## Summary
- split envelope views into guest and recipient modules
- extract shared helpers for guest token and PDF serving
- update signature URLs to use new modules

## Testing
- `DJANGO_SECRET_KEY=foo POSTGRES_DB=foo POSTGRES_USER=foo POSTGRES_PASSWORD=foo POSTGRES_HOST=localhost POSTGRES_PORT=5432 EMAIL_HOST_USER=foo EMAIL_HOST_PASSWORD=bar FRONT_BASE_URL=http://example.com python manage.py test` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4c54ff08333b73270da7f78afaa