### PR TITLE
Drop MD5 hashing in favor of SHA-256

### DIFF
--- a/backend/signature/crypto_utils.py
+++ b/backend/signature/crypto_utils.py
@@ -44,8 +44,12 @@ def extract_signer_certificate_info():
         "serial_number": str(cert.serial_number),
     }
 def compute_hashes(pdf_bytes: bytes):
+    """Compute cryptographic hashes for a PDF.
+
+    Only SHA-256 is returned since MD5 is considered insecure due to
+    widespread collision attacks.
+    """
     return {
-        "hash_md5": hashlib.md5(pdf_bytes).hexdigest(),
         "hash_sha256": hashlib.sha256(pdf_bytes).hexdigest(),
     }
 

--- a/backend/signature/views/envelope.py
+++ b/backend/signature/views/envelope.py
@@ -25,7 +25,7 @@ from ..hsm import hsm_sign
 from jwt import InvalidTokenError, ExpiredSignatureError
 from ..models import ( Envelope,EnvelopeRecipient,SignatureDocument,PrintQRCode,EnvelopeDocument,)
 from ..serializers import (EnvelopeSerializer,EnvelopeListSerializer,SigningFieldSerializer,SignatureDocumentSerializer,PrintQRCodeSerializer,)
-from signature.crypto_utils import sign_pdf_bytes,compute_hashes, extract_signer_certificate_info
+from signature.crypto_utils import sign_pdf_bytes, extract_signer_certificate_info
 from reportlab.pdfgen import canvas
 from django.core.files.base import ContentFile
 from PyPDF2 import PdfReader, PdfWriter

--- a/frontend/src/pages/QrVerifyPage.jsx
+++ b/frontend/src/pages/QrVerifyPage.jsx
@@ -146,7 +146,6 @@ export default function QrVerifyPage() {
           </h2>
 
           <dl className="space-y-0">
-            <InfoItem label="MD5" value={data?.hash_md5} icon={Hash} type="code" />
             <InfoItem label="SHA-256" value={data?.hash_sha256} icon={Hash} type="code" />
           </dl>
         </Card>


### PR DESCRIPTION
## Summary
- remove MD5 from `compute_hashes` and return only SHA-256
- update QR verification page to display only SHA-256
- clean unused import from envelope view

## Testing
- `python manage.py test` *(fails: DJANGO_SECRET_KEY not set)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab2d98f128833391bd19cc0ebd306a