### PR TITLE
fix: import EmailTemplates in serializers

### DIFF
--- a/backend/signature/serializers.py
+++ b/backend/signature/serializers.py
@@ -4,6 +4,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.conf import settings
 from django.db import transaction
 from rest_framework.reverse import reverse
+from .email_utils import EmailTemplates
 from .models import (SavedSignature, FieldTemplate, BatchSignJob, BatchSignItem,
     Envelope,EnvelopeRecipient,SigningField,SignatureDocument,PrintQRCode,
     NotificationPreference,EnvelopeDocument,


### PR DESCRIPTION
## Summary
- import EmailTemplates in serializers to support password reset emails

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test` *(fails: Set the DJANGO_SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5148fce083338c48fedc8626e593