### PR TITLE
Fix envelope list initiator field and update UI

### DIFF
--- a/backend/signature/serializers.py
+++ b/backend/signature/serializers.py
@@ -499,6 +499,7 @@ class BatchSignJobSerializer(serializers.ModelSerializer):
 class EnvelopeListSerializer(serializers.ModelSerializer):
     recipients_count = serializers.IntegerField(source='recipients.count', read_only=True)
     completion_rate = serializers.ReadOnlyField()
+    created_by_name = serializers.SerializerMethodField()
 
     class Meta:
         model = Envelope
@@ -506,13 +507,18 @@ class EnvelopeListSerializer(serializers.ModelSerializer):
             'id',
             'title',
             'status',
-            'initiateur',
+            'created_by',
+            'created_by_name',
             'created_at',
             'deadline_at',
             'recipients_count',
             'completion_rate',
             'flow_type',
         ]
+
+    def get_created_by_name(self, obj):
+        name = obj.created_by.get_full_name().strip()
+        return name or obj.created_by.username
 
 
 class SignatureDocumentSerializer(serializers.ModelSerializer):

--- a/frontend/src/components/CompletedEnvelopes.js
+++ b/frontend/src/components/CompletedEnvelopes.js
@@ -55,7 +55,7 @@ const CompletedEnvelopes = () => {
           <div className="text-sm font-semibold text-gray-900 truncate">{row.title}</div>
           <div className="flex items-center text-xs text-gray-500 mt-1">
             <User className="w-3 h-3 mr-1" />
-            <span>Initiateur: {row.created_by_name || row.created_by || 'Non spécifié'}</span>
+            <span>Initiateur: {row.created_by_name || 'Non spécifié'}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/DeletedEnvelopes.js
+++ b/frontend/src/components/DeletedEnvelopes.js
@@ -25,7 +25,7 @@ const DeletedEnvelopes = () => {
   const DocumentCell = ({ row }) => (
     <div>
       <div className="text-base font-medium text-gray-900">{row.title}</div>
-      <div className="text-xs text-gray-500 mt-1">Initiateur: {row.created_by?.full_name || 'Non spécifié'}</div>
+      <div className="text-xs text-gray-500 mt-1">Initiateur: {row.created_by_name || 'Non spécifié'}</div>
     </div>
   );
 


### PR DESCRIPTION
## Summary
- replace obsolete `initiateur` with `created_by` and `created_by_name` in envelope list serializer
- show initiator name using `created_by_name` in envelope list components

## Testing
- `pytest signature/tests` *(fails: Set the EMAIL_HOST_USER environment variable)*
- `npm install` *(fails: canvas build missing pixman-1)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ce0e1cc8333a5256ed1821fa1f4