### PR TITLE
feat: handle token expiry on refresh failure

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from 'react-router-dom';
 
 import DashboardSignature from './pages/DashboardSignature';
@@ -26,7 +26,6 @@ import DeletedEnvelopes from './components/DeletedEnvelopes';
 import MainLayout from './layouts/MainLayout';
 import QrVerifyPage from './pages/QrVerifyPage';
 import { useAuth } from './AuthContext';
-import { setLogoutCallback } from './services/apiUtils';
 
 const ProtectedRoute = () => {
   const { isAuthenticated } = useAuth();
@@ -40,12 +39,7 @@ const LoadingSpinner = () => (
 );
 
 const App = () => {
-  const { isLoading, handleTokenExpiry } = useAuth();
-
-  // Configurer le callback de déconnexion pour apiUtils
-  useEffect(() => {
-    setLogoutCallback(handleTokenExpiry);
-  }, [handleTokenExpiry]);
+  const { isLoading } = useAuth();
 
   // Afficher le spinner pendant le chargement de l'authentification
   if (isLoading) {

--- a/frontend/src/AuthContext.js
+++ b/frontend/src/AuthContext.js
@@ -37,9 +37,15 @@ export const AuthProvider = ({ children }) => {
     navigate('/login');
   };
 
+  // Gère l'expiration de session côté client
+  const handleTokenExpiry = () => {
+    toast.error('Votre session a expiré. Veuillez vous reconnecter.');
+    logout();
+  };
+
   useEffect(() => {
-    // permet à axios-auth-refresh de déconnecter si refresh échoue
-    setLogoutCallback(logout);
+    // permet à axios-auth-refresh de déconnecter si le refresh échoue
+    setLogoutCallback(handleTokenExpiry);
 
     const init = async () => {
       try {
@@ -61,7 +67,8 @@ export const AuthProvider = ({ children }) => {
       isAuthenticated: !!user,
       isLoading,
       login,
-      logout
+      logout,
+      handleTokenExpiry
     }}>
       {children}
     </AuthContext.Provider>

--- a/frontend/src/services/apiUtils.test.js
+++ b/frontend/src/services/apiUtils.test.js
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import { api, setLogoutCallback } from './apiUtils';
+
+describe('refresh failure handling', () => {
+  const originalAdapter = api.defaults.adapter;
+
+  afterEach(() => {
+    api.defaults.adapter = originalAdapter;
+    jest.restoreAllMocks();
+  });
+
+  test('redirects to /login when refresh fails', async () => {
+    const navigate = jest.fn();
+    setLogoutCallback(() => navigate('/login'));
+
+    // Simulate a request returning 401
+    api.defaults.adapter = () =>
+      Promise.reject({
+        response: { status: 401, config: { url: '/protected' } },
+      });
+
+    // Simulate refresh token failure
+    jest.spyOn(axios, 'post').mockImplementation((url) => {
+      if (url.includes('/api/token/refresh/')) {
+        return Promise.reject(new Error('Refresh failed'));
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(api.get('/protected')).rejects.toBeDefined();
+
+    expect(navigate).toHaveBeenCalledWith('/login');
+  });
+});


### PR DESCRIPTION
## Summary
- add `handleTokenExpiry` in auth context and register with `setLogoutCallback`
- simplify App initialization now that token expiry handled centrally
- test refresh failure redirects to `/login`

## Testing
- `npm ci --omit=optional` *(fails: Package 'pixman-1', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6289ee1483338cf7474d2989b32c