### PR TITLE
refactor: centralize PDF validation

### DIFF
--- a/backend/signature/utils.py
+++ b/backend/signature/utils.py
@@ -1,0 +1,51 @@
+# signature/utils.py
+
+"""Utilities for the signature app."""
+
+import io
+import logging
+
+from django.core.exceptions import ValidationError
+from PyPDF2 import PdfReader
+
+logger = logging.getLogger(__name__)
+
+
+def validate_pdf(file) -> None:
+    """Validate an uploaded PDF file.
+
+    Checks extension, size, header and at least one page. Raises
+    :class:`ValidationError` if the file is invalid.
+    """
+
+    if not file:
+        return
+
+    # Extension
+    ext = file.name.split(".")[-1].lower() if "." in file.name else ""
+    if ext != "pdf":
+        raise ValidationError(f"Type de fichier non autorisé: {ext} (PDF uniquement)")
+
+    # Size
+    if file.size > 10 * 1024 * 1024:
+        raise ValidationError("Fichier trop volumineux (max 10MB)")
+
+    if file.size == 0:
+        raise ValidationError("Le fichier est vide.")
+
+    # Header and pages
+    try:
+        file.seek(0)
+        content = file.read()
+        file.seek(0)
+        if not content.startswith(b"%PDF-"):
+            raise ValidationError("Le fichier PDF est corrompu ou invalide.")
+        pdf = PdfReader(io.BytesIO(content))
+        if len(pdf.pages) == 0:
+            raise ValidationError("Le PDF est vide.")
+    except ValidationError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("PDF validation error: %s", exc)
+        raise ValidationError("Le fichier PDF est corrompu ou invalide.")
+


### PR DESCRIPTION
## Summary
- add shared `validate_pdf` utility
- use `validate_pdf` in envelope models

## Testing
- `POSTGRES_DB=test POSTGRES_USER=test POSTGRES_PASSWORD=test POSTGRES_HOST=localhost POSTGRES_PORT=5432 DJANGO_SECRET_KEY=test EMAIL_HOST_USER=test@example.com EMAIL_HOST_PASSWORD=test FRONT_BASE_URL=http://localhost python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6605c0188333b6240988141c36af