### PR TITLE
Use context managers for file access

### DIFF
--- a/backend/signature/models.py
+++ b/backend/signature/models.py
@@ -99,10 +99,9 @@ class EnvelopeDocument(models.Model):
             # Hash clair (pour traçabilité) si PDF
             if self.file_type == "pdf":
                 try:
-                    self.file.seek(0)
-                    content = self.file.read()
+                    with self.file.open("rb") as f:
+                        content = f.read()
                     self.hash_original = _sha256(content)
-                    self.file.seek(0)
                 except Exception as e:
                     logger.error(f"Error computing hash for envelope document: {e}")
 
@@ -235,10 +234,9 @@ class Envelope(models.Model):
             # Hash clair si PDF
             if self.file_type == "pdf":
                 try:
-                    self.document_file.seek(0)
-                    content = self.document_file.read()
+                    with self.document_file.open("rb") as f:
+                        content = f.read()
                     self.hash_original = self.compute_hash(content)
-                    self.document_file.seek(0)
                 except Exception as e:
                     logger.error(f"Error computing hash for envelope: {e}")
 


### PR DESCRIPTION
## Summary
- Use context manager when reading final signed PDF and other files in task handlers
- Apply context managers when hashing uploaded documents in models to ensure proper file closure

## Testing
- `DJANGO_SECRET_KEY=test POSTGRES_DB=testdb POSTGRES_USER=test POSTGRES_PASSWORD=test POSTGRES_HOST=localhost POSTGRES_PORT=5432 EMAIL_HOST_USER=test@example.com EMAIL_HOST_PASSWORD=test FRONT_BASE_URL=http://localhost python manage.py test signature.tests.test_email_utils -v 2` *(fails: connection to server at "localhost" port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6e9e4cb88333ab8c9cbbaa3e45cd