### PR TITLE
Log registration email errors and configure logging

### DIFF
--- a/backend/esign/settings.py
+++ b/backend/esign/settings.py
@@ -205,3 +205,18 @@ MEDIA_ROOT = BASE_DIR / 'media'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
+}

--- a/backend/signature/views/auth.py
+++ b/backend/signature/views/auth.py
@@ -13,6 +13,7 @@ from django.utils.encoding import force_bytes, force_str
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth import get_user_model
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+import logging
 
 from ..serializers import (
     UserRegistrationSerializer,
@@ -23,6 +24,7 @@ from ..serializers import (
 from ..email_utils import EmailTemplates
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 class CookieTokenObtainPairView(TokenObtainPairView):
@@ -89,6 +91,7 @@ def register(request):
                 status=status.HTTP_201_CREATED,
             )
         except Exception as e:
+            logger.exception("Erreur lors de l'envoi de l'email d'activation")
             # Fallback en cas d'erreur d'envoi d'email
             return Response(
                 {'detail': 'Inscription réussie mais erreur d\'envoi d\'email. Contactez le support.'},


### PR DESCRIPTION
## Summary
- add logger to auth view and log exceptions when activation email fails
- set up basic console logging in Django settings

## Testing
- `python manage.py test -q` *(fails: Set the DJANGO_SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2acb0bc883338190564ded239fca