### PR TITLE
Check content type before allowing iframe

### DIFF
--- a/backend/signature/tests/test_middleware.py
+++ b/backend/signature/tests/test_middleware.py
@@ -1,0 +1,23 @@
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from signature.middleware import AllowIframeForPDFOnlyMiddleware
+
+
+class AllowIframeForPDFOnlyMiddlewareTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(SIGNATURE_X_FRAME_OPTIONS="ALLOW-FROM https://example.com")
+    def test_allows_iframe_for_pdf_responses(self):
+        middleware = AllowIframeForPDFOnlyMiddleware(lambda req: HttpResponse(content_type="application/pdf"))
+        request = self.factory.get("/api/signature/envelopes/1/signed-document/")
+        response = middleware(request)
+        self.assertEqual(response.headers["X-Frame-Options"], "ALLOW-FROM https://example.com")
+
+    @override_settings(SIGNATURE_X_FRAME_OPTIONS="ALLOW-FROM https://example.com")
+    def test_restricts_non_pdf_responses(self):
+        middleware = AllowIframeForPDFOnlyMiddleware(lambda req: HttpResponse(content_type="text/plain"))
+        request = self.factory.get("/api/signature/envelopes/1/signed-document/")
+        response = middleware(request)
+        self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")


### PR DESCRIPTION
## Summary
- verify response Content-Type before relaxing iframe restrictions
- default to SAMEORIGIN when content is not a PDF
- add unit tests for middleware behavior

## Testing
- `DJANGO_SETTINGS_MODULE=esign.settings DJANGO_SECRET_KEY=dummy POSTGRES_DB=test POSTGRES_USER=test POSTGRES_PASSWORD=test POSTGRES_HOST=localhost POSTGRES_PORT=5432 EMAIL_HOST_USER=test EMAIL_HOST_PASSWORD=test FRONT_BASE_URL=http://example.com pytest signature/tests/test_middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac357237b8833388eb79f6c431a581