### PR TITLE
Protect verify_token endpoint with authentication

### DIFF
--- a/backend/signature/tests/test_views.py
+++ b/backend/signature/tests/test_views.py
@@ -8,6 +8,11 @@ class AuthTests(APITestCase):
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
 
+    def test_verify_token_unauthenticated(self):
+        url = reverse('verify_token')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
 class EnvelopeTests(APITestCase):
     def test_guest_envelope_not_found(self):
         url = reverse('guest-envelope', kwargs={'pk': 999})

--- a/backend/signature/views/auth.py
+++ b/backend/signature/views/auth.py
@@ -148,28 +148,22 @@ def change_password(request):
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(['GET'])
-@permission_classes([AllowAny])
+@permission_classes([IsAuthenticated])
 def verify_token(request):
     """Endpoint pour vérifier la validité du token JWT"""
-    try:
-        user = request.user
-        return Response({
-            'valid': True,
-            'user': {
-                'id': user.id,
-                'username': user.username,
-                'email': user.email,
-                'first_name': user.first_name,
-                'last_name': user.last_name,
-                'birth_date': user.birth_date,
-                'phone_number': user.phone_number,
-                'gender': user.gender,
-                'address': user.address,
-                'avatar': user.avatar.url if user.avatar else None,
-            }
-        }, status=status.HTTP_200_OK)
-    except Exception as e:
-        return Response({
-            'valid': False,
-            'error': str(e)
-        }, status=status.HTTP_401_UNAUTHORIZED)
+    user = request.user
+    return Response({
+        'valid': True,
+        'user': {
+            'id': user.id,
+            'username': user.username,
+            'email': user.email,
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'birth_date': user.birth_date,
+            'phone_number': user.phone_number,
+            'gender': user.gender,
+            'address': user.address,
+            'avatar': user.avatar.url if user.avatar else None,
+        }
+    }, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- Require authentication for `verify_token` endpoint and let DRF handle invalid tokens
- Test that unauthenticated requests to `verify_token` receive 401

## Testing
- `DJANGO_SECRET_KEY=test POSTGRES_DB=testdb POSTGRES_USER=user POSTGRES_PASSWORD=password POSTGRES_HOST=localhost POSTGRES_PORT=5432 EMAIL_HOST_USER=test@example.com EMAIL_HOST_PASSWORD=test FRONT_BASE_URL=http://localhost python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ac43906a8c8333ae112df10e44f456