### PR TITLE
Add throttling to registration and password reset views

### DIFF
--- a/backend/esign/settings.py
+++ b/backend/esign/settings.py
@@ -134,6 +134,14 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '1/minute',
+        'user': '1/minute',
+    },
 }
 
 CELERY_BROKER_URL = env.str('CELERY_BROKER_URL', 'redis://localhost:6379/0')

--- a/backend/signature/tests/test_views.py
+++ b/backend/signature/tests/test_views.py
@@ -1,5 +1,7 @@
 from django.urls import reverse
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from rest_framework import status
 from rest_framework.test import APITestCase
 
 class AuthTests(APITestCase):
@@ -23,3 +25,28 @@ class NotificationTests(APITestCase):
         url = reverse('notifications-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+
+class ThrottleTests(APITestCase):
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_register_throttled(self):
+        url = reverse('register')
+        response1 = self.client.post(url, {})
+        self.assertEqual(response1.status_code, 400)
+        response2 = self.client.post(url, {})
+        self.assertEqual(response2.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_password_reset_throttled(self):
+        user = get_user_model().objects.create_user(
+            username='foo', email='foo@example.com', password='bar'
+        )
+        url = reverse('password-reset')
+        response1 = self.client.post(url, {'email': user.email})
+        self.assertEqual(response1.status_code, 200)
+        response2 = self.client.post(url, {'email': user.email})
+        self.assertEqual(response2.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/backend/signature/views/auth.py
+++ b/backend/signature/views/auth.py
@@ -1,7 +1,7 @@
 # signature/views/auth.py (mis à jour)
 
 from rest_framework import status
-from rest_framework.decorators import api_view, permission_classes, parser_classes
+from rest_framework.decorators import api_view, permission_classes, parser_classes, throttle_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.response import Response
@@ -12,6 +12,7 @@ from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes, force_str
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth import get_user_model
+from rest_framework.throttling import UserRateThrottle, AnonRateThrottle
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 import logging
 
@@ -73,6 +74,7 @@ def logout(request):
 @api_view(['POST'])
 @permission_classes([AllowAny])
 @parser_classes([MultiPartParser, FormParser])
+@throttle_classes([UserRateThrottle, AnonRateThrottle])
 def register(request):
     serializer = UserRegistrationSerializer(data=request.data)
     if serializer.is_valid():
@@ -130,6 +132,7 @@ def user_profile(request):
 
 @api_view(['POST'])
 @permission_classes([AllowAny])
+@throttle_classes([UserRateThrottle, AnonRateThrottle])
 def password_reset_request(request):
     serializer = PasswordResetSerializer(data=request.data, context={'request': request})
     if serializer.is_valid():


### PR DESCRIPTION
## Summary
- enable DRF anon/user throttles in settings
- throttle register and password reset endpoints
- test rate limiting behavior

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ac43ed1ca483338f062e8eeca8a13d