### PR TITLE
Improve ClamAV middleware with in-memory scanning

### DIFF
--- a/backend/signature/tests/test_middleware.py
+++ b/backend/signature/tests/test_middleware.py
@@ -1,7 +1,10 @@
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.exceptions import SuspiciousFileOperation
+from unittest import mock
 
-from signature.middleware import AllowIframeForPDFOnlyMiddleware
+from signature.middleware import AllowIframeForPDFOnlyMiddleware, ClamAVMiddleware
 
 
 class AllowIframeForPDFOnlyMiddlewareTests(SimpleTestCase):
@@ -21,3 +24,24 @@ class AllowIframeForPDFOnlyMiddlewareTests(SimpleTestCase):
         request = self.factory.get("/api/signature/envelopes/1/signed-document/")
         response = middleware(request)
         self.assertEqual(response.headers["X-Frame-Options"], "SAMEORIGIN")
+
+
+class ClamAVMiddlewareTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_eicar_signature_is_blocked(self):
+        eicar = (
+            b"X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+        )
+        upload = SimpleUploadedFile("eicar.com", eicar)
+        request = self.factory.post("/upload/", {"file": upload})
+
+        middleware = ClamAVMiddleware(lambda req: None)
+        middleware.use_clamd = False
+
+        fake_result = mock.Mock(returncode=1, stdout="stdin: Eicar-Test-Signature FOUND\n", stderr="")
+        with mock.patch("subprocess.run", return_value=fake_result) as mrun:
+            with self.assertRaises(SuspiciousFileOperation):
+                middleware.process_request(request)
+            self.assertTrue(mrun.called)


### PR DESCRIPTION
## Summary
- reduce disk writes by scanning uploads from a SpooledTemporaryFile
- allow optional background-thread scanning via `CLAMAV_ASYNC`
- add EICAR-based unit test for ClamAV middleware

## Testing
- `POSTGRES_DB=db POSTGRES_USER=user POSTGRES_PASSWORD=pw POSTGRES_HOST=localhost POSTGRES_PORT=5432 DJANGO_SECRET_KEY=testsecret EMAIL_HOST_USER=user@example.com EMAIL_HOST_PASSWORD=pw FRONT_BASE_URL=http://localhost python manage.py test signature.tests.test_middleware -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68ac43c5b980833385939d86fbc3559c