### PR TITLE
Add global ErrorBoundary component

### DIFF
--- a/frontend/src/components/ErrorBoundary.js
+++ b/frontend/src/components/ErrorBoundary.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // You can log the error to an error reporting service here
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="h-screen flex flex-col items-center justify-center p-4 text-center">
+          <h1 className="text-2xl font-bold mb-4">Une erreur s'est produite</h1>
+          <Link to="/" className="text-blue-500 underline">
+            Retour à l'accueil
+          </Link>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,15 +5,18 @@ import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './AuthContext';
 import { pdfjs } from 'react-pdf';
 import { ToastContainer } from 'react-toastify';
+import ErrorBoundary from './components/ErrorBoundary';
 import 'react-toastify/dist/ReactToastify.css';
 pdfjs.GlobalWorkerOptions.workerSrc =
   `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <BrowserRouter>
-    <AuthProvider>
-      <App />
-      <ToastContainer />
-    </AuthProvider>
+    <ErrorBoundary>
+      <AuthProvider>
+        <App />
+        <ToastContainer />
+      </AuthProvider>
+    </ErrorBoundary>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- create ErrorBoundary component with componentDidCatch and friendly fallback
- wrap application with ErrorBoundary in index.js

## Testing
- `npm test -- --watchAll=false` *(fails: sh: 1: react-scripts: not found)*
- `npm install` *(fails: canvas build error: Package pixman-1 was not found in the pkg-config search path)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5207c4483338ea4aa29edaccc0c