### PR TITLE
feat: add environment-aware log service

### DIFF
--- a/frontend/src/components/ActionRequiredEnvelopes.js
+++ b/frontend/src/components/ActionRequiredEnvelopes.js
@@ -3,6 +3,7 @@ import Table from '../components/Tables';
 import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
+import logService from '../services/logService';
 
 const ActionRequiredEnvelopes = () => {
   const [envelopes, setEnvelopes] = useState([]);
@@ -16,7 +17,7 @@ const ActionRequiredEnvelopes = () => {
         setEnvelopes(data);
       } catch (err) {
         toast.error("Impossible de charger les actions requises");
-        console.error(err);
+        logService.error(err);
       } finally {
         setLoading(false);
       }

--- a/frontend/src/components/CompletedEnvelopes.js
+++ b/frontend/src/components/CompletedEnvelopes.js
@@ -6,6 +6,7 @@ import { FiMoreVertical, FiDownload, FiPrinter, FiTrash2, FiEye } from 'react-ic
 import { CheckCircle, FileText, Calendar, User } from 'lucide-react';
 import slugify from 'slugify';
 import { useNavigate } from "react-router-dom";
+import logService from '../services/logService';
 
 
 
@@ -24,7 +25,7 @@ const CompletedEnvelopes = () => {
         setEnvelopes(data);
       } catch (err) {
         toast.error('Échec du chargement des enveloppes');
-        console.error(err);
+        logService.error(err);
       } finally {
         setLoading(false);
       }
@@ -112,7 +113,7 @@ const CompletedEnvelopes = () => {
       toast.success('Document téléchargé avec succès');
     } catch (err) {
       toast.error('Échec du téléchargement');
-      console.error(err);
+      logService.error(err);
     }
   };
 
@@ -128,7 +129,7 @@ const CompletedEnvelopes = () => {
       }
     } catch (err) {
       toast.error('Échec de l\'impression');
-      console.error(err);
+      logService.error(err);
     }
   };
 
@@ -141,7 +142,7 @@ const CompletedEnvelopes = () => {
       toast.success('Enveloppe supprimée avec succès');
     } catch (err) {
       toast.error('Échec de la suppression');
-      console.error(err);
+      logService.error(err);
     }
   };
 

--- a/frontend/src/components/DeletedEnvelopes.js
+++ b/frontend/src/components/DeletedEnvelopes.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Table from '../components/Tables';
 import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
+import logService from '../services/logService';
 
 const DeletedEnvelopes = () => {
   const [envelopes, setEnvelopes] = useState([]);
@@ -14,7 +15,7 @@ const DeletedEnvelopes = () => {
         setEnvelopes(data);
       } catch (err) {
         toast.error('Échec du chargement des enveloppes supprimées');
-        console.error('Failed to fetch deleted envelopes:', err);
+        logService.error('Failed to fetch deleted envelopes:', err);
       } finally {
         setLoading(false);
       }

--- a/frontend/src/components/DraftEnvelopes.js
+++ b/frontend/src/components/DraftEnvelopes.js
@@ -5,6 +5,7 @@ import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
 import { FiEdit2, FiTrash2 } from 'react-icons/fi';
+import logService from '../services/logService';
 
 const DraftEnvelopes = () => {
   const [envelopes, setEnvelopes] = useState([]);
@@ -18,7 +19,7 @@ const DraftEnvelopes = () => {
         setEnvelopes(data);
       } catch (err) {
         toast.error('Échec du chargement des brouillons');
-        console.error('Failed to fetch draft envelopes:', err);
+        logService.error('Failed to fetch draft envelopes:', err);
       } finally {
         setLoading(false);
       }
@@ -39,7 +40,7 @@ const DraftEnvelopes = () => {
       toast.success('Brouillon supprimé');
     } catch (err) {
       toast.error('Échec de la suppression');
-      console.error(err);
+      logService.error(err);
     }
   };
 

--- a/frontend/src/components/SentEnvelopes.js
+++ b/frontend/src/components/SentEnvelopes.js
@@ -3,6 +3,7 @@ import Table from '../components/Tables';
 import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
+import logService from '../services/logService';
 
 const SentEnvelopes = () => {
   const [envelopes, setEnvelopes] = useState([]);
@@ -11,7 +12,7 @@ const SentEnvelopes = () => {
     signatureService.getEnvelopes({ status: 'sent' })
       .then(setEnvelopes)
       .catch(err => {
-        console.error(err);
+        logService.error(err);
         toast.error("Impossible de charger les enveloppes envoyées");
       });
   }, []);

--- a/frontend/src/components/SignaturePadComponent.js
+++ b/frontend/src/components/SignaturePadComponent.js
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useCallback } from 'react';
 import SignatureCanvas from 'react-signature-canvas';
+import logService from '../services/logService';
 
 const SignaturePadComponent = ({ onEnd, onChange, initialValue, canvasProps }) => {
   const sigRef = useRef(null);
@@ -10,7 +11,7 @@ const SignaturePadComponent = ({ onEnd, onChange, initialValue, canvasProps }) =
     try {
       sigRef.current.fromDataURL(initialValue);
     } catch (error) {
-      console.error('Erreur lors du chargement de la signature :', error);
+      logService.error('Erreur lors du chargement de la signature :', error);
     }
   }, [initialValue]);
 

--- a/frontend/src/pages/DashboardSignature.js
+++ b/frontend/src/pages/DashboardSignature.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';              
+import { Link } from 'react-router-dom';
 import SignatureNavbar from '../components/SignatureNavbar';
 import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
 import slugify from 'slugify';
+import logService from '../services/logService';
 
 import {
   FileText,
@@ -96,7 +97,7 @@ const DashboardSignature = () => {
         setNotifications(notifs);
         setRecentDocuments(recents);
       } catch (err) {
-        console.error('Erreur chargement dashboard:', err);
+        logService.error('Erreur chargement dashboard:', err);
         toast.error('Échec du chargement du tableau de bord');
       }
     };
@@ -109,7 +110,7 @@ const DashboardSignature = () => {
       const { download_url } = await signatureService.downloadEnvelope(id);
       window.open(download_url, '_blank');
     } catch (error) {
-      console.error('Erreur lors de la prévisualisation du PDF:', error);
+      logService.error('Erreur lors de la prévisualisation du PDF:', error);
       toast.error('Impossible de prévisualiser le PDF');
     }
   };
@@ -135,7 +136,7 @@ const DashboardSignature = () => {
 
       toast.success('Document téléchargé avec succès');
     } catch (err) {
-      console.error('Erreur lors du téléchargement du PDF:', err);
+      logService.error('Erreur lors du téléchargement du PDF:', err);
       toast.error('Échec du téléchargement du document');
     }
   };

--- a/frontend/src/pages/DocumentDetail.js
+++ b/frontend/src/pages/DocumentDetail.js
@@ -10,6 +10,7 @@ import { toast } from 'react-toastify';
 import Countdown from '../components/Countdown';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
+import logService from '../services/logService';
 
 // ⬆️ tout en haut de src/pages/DocumentDetail.js (après les imports)
 function ReminderModal({ open, count, onClose }) {
@@ -108,7 +109,7 @@ const [reminderCount, setReminderCount] = useState(0);
       });
       setNumPages(0);
     } catch (e) {
-      console.error(e);
+      logService.error(e);
       setPdfUrl(null);
       toast.error('Impossible de charger le PDF');
     } finally {
@@ -127,7 +128,7 @@ const [reminderCount, setReminderCount] = useState(0);
         if (docs.length > 0) setSelectedDoc(docs[0]); // pour l’UI
         await loadConsolidatedPreview(); // toujours la version consolidée
       } catch (err) {
-        console.error(err);
+        logService.error(err);
         toast.error("Échec du chargement de l'enveloppe");
       } finally {
         setLoading(false);
@@ -167,7 +168,7 @@ const [reminderCount, setReminderCount] = useState(0);
       document.body.removeChild(a);
       toast.success('Document téléchargé');
     } catch (e) {
-      console.error(e);
+      logService.error(e);
       toast.error('Échec du téléchargement');
     }
   };
@@ -175,7 +176,7 @@ const [reminderCount, setReminderCount] = useState(0);
   // Callbacks react-pdf
   const onDocumentLoad = ({ numPages }) => setNumPages(numPages);
   const onDocumentError = (err) => {
-    console.error('PDF error:', err);
+    logService.error('PDF error:', err);
     toast.error('Erreur lors du chargement du PDF');
   };
 

--- a/frontend/src/pages/DocumentSign.js
+++ b/frontend/src/pages/DocumentSign.js
@@ -12,6 +12,7 @@ import { api } from '../services/apiUtils'; // ✅ axios (baseURL)
 import SignaturePadComponent from '../components/SignaturePadComponent';
 import Modal from 'react-modal';
 import Countdown from '../components/Countdown';
+import logService from '../services/logService';
 
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
@@ -172,7 +173,7 @@ async function urlToDataUrl(url) {
           setOtpVerified(true);
         }
       } catch (err) {
-        console.error(err);
+        logService.error(err);
         toast.error(err?.response?.data?.error || 'Impossible de charger la page de signature');
         navigate('/');
         return;
@@ -231,7 +232,7 @@ async function urlToDataUrl(url) {
         setPdfUrl(blobUrl);
       } catch (e) {
         if (!alive) return;
-        console.error('Erreur lors du chargement du document:', e);
+        logService.error('Erreur lors du chargement du document:', e);
         toast.error(`Impossible de charger ce PDF: ${e.message}`);
       }
     };
@@ -249,7 +250,7 @@ async function urlToDataUrl(url) {
       setOtpSent(true);
       toast.success('Code OTP envoyé');
     } catch (e) {
-      console.error(e);
+      logService.error(e);
       toast.error(e?.response?.data?.error || 'Erreur envoi OTP');
     } finally {
       setSendingOtp(false);
@@ -278,11 +279,11 @@ async function urlToDataUrl(url) {
         }
         if (blobUrl) setPdfUrl(blobUrl);
       } catch (pdfError) {
-        console.error('Erreur lors du rechargement du PDF:', pdfError);
+        logService.error('Erreur lors du rechargement du PDF:', pdfError);
         toast.error('PDF vérifié mais erreur de chargement. Veuillez rafraîchir la page.');
       }
     } catch (e) {
-      console.error(e);
+      logService.error(e);
       const msg = e?.response?.data?.error || 'OTP invalide';
       setOtpError(msg);
       toast.error(msg);
@@ -294,7 +295,7 @@ async function urlToDataUrl(url) {
   // PDF callbacks
   const onDocumentLoad = ({ numPages }) => setNumPages(numPages);
   const onDocumentError = (err) => {
-    console.error('PDF error:', err);
+    logService.error('PDF error:', err);
     toast.error('Erreur chargement PDF');
   };
   const onPageLoadSuccess = (num, page) => {
@@ -388,7 +389,7 @@ async function urlToDataUrl(url) {
         });
       }
     } catch (e) {
-      console.error(e);
+      logService.error(e);
       toast.error(e?.response?.data?.error || 'Erreur lors de la signature');
     } finally {
       setSigning(false);
@@ -724,7 +725,7 @@ async function urlToDataUrl(url) {
     setUploadPreview(dataUrl);
     setSavedSelectedId(sig.id);
   } catch (err) {
-    console.error("Erreur chargement signature:", err);
+    logService.error("Erreur chargement signature:", err);
     toast.error("Impossible de charger la signature enregistrée");
   }
 }}

--- a/frontend/src/pages/DocumentUpload.js
+++ b/frontend/src/pages/DocumentUpload.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
 import { FiUpload, FiFileText } from 'react-icons/fi';
+import logService from '../services/logService';
 
 const DocumentUpload = () => {
   const [files, setFiles] = useState([]);
@@ -47,7 +48,7 @@ const DocumentUpload = () => {
       toast.success('Document téléversé avec succès');
       navigate(`/signature/workflow/${response.id}`);
     } catch (error) {
-      console.error('Erreur lors du téléversement:', error);
+      logService.error('Erreur lors du téléversement:', error);
       toast.error(error.response?.data?.detail || 'Erreur lors du téléversement du document');
     }
   };

--- a/frontend/src/pages/DocumentWorkflow.js
+++ b/frontend/src/pages/DocumentWorkflow.js
@@ -5,6 +5,7 @@ import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
+import logService from '../services/logService';
 
 
 pdfjs.GlobalWorkerOptions.workerSrc =
@@ -58,7 +59,7 @@ const [includeQr, setIncludeQr] = useState(false);
       toast.success('Fichiers ajoutés');
       await reloadEnvelope(); // recharge tout
     } catch (e) {
-      console.error(e);
+      logService.error(e);
       toast.error("Échec de l'upload");
     } finally {
       setIsUploading(false);
@@ -157,7 +158,7 @@ const [includeQr, setIncludeQr] = useState(false);
   }, [selectedDocId]);
 
   const onDocumentError = useCallback((err) => {
-    console.error('PDF Error:', err);
+    logService.error('PDF Error:', err);
     toast.error('Erreur lors du chargement du PDF');
   }, []);
 
@@ -179,7 +180,7 @@ const selectDocument = useCallback(async (doc) => {
  setSelectedDocId(doc.id); // 2) puis l'ID (affichage, badges, etc.)
  setNumPagesByDoc(prev => ({ ...prev, [doc.id]: undefined }));
   } catch (e) {
-    console.error(e);
+    logService.error(e);
     toast.error('Impossible de charger ce PDF');
   } finally {
     // (optionnel) setLoadingDocId(null);
@@ -314,7 +315,7 @@ const selectDocument = useCallback(async (doc) => {
       toast.success('Enveloppe envoyée');
       navigate(`/signature/sent/${id}`);
     } catch (err) {
-      console.error(err);
+      logService.error(err);
       toast.error("Échec de l'envoi");
     }
   }, [id, recipients, fields, flowType, includeQr, navigate]);

--- a/frontend/src/pages/EnvelopeSent.js
+++ b/frontend/src/pages/EnvelopeSent.js
@@ -15,6 +15,7 @@ import {
   ExternalLink,
   Download
 } from 'lucide-react';
+import logService from '../services/logService';
 
 export default function EnvelopeSent() {
   const { id } = useParams();
@@ -29,7 +30,7 @@ export default function EnvelopeSent() {
         const data = await signatureService.getEnvelope(id);
         setEnvelope(data);
       } catch (error) {
-        console.error("Erreur lors du chargement de l'enveloppe:", error);
+        logService.error("Erreur lors du chargement de l'enveloppe:", error);
         setEnvelope(null);
       } finally {
         setLoading(false);

--- a/frontend/src/pages/GuestSignatureConfirmation.js
+++ b/frontend/src/pages/GuestSignatureConfirmation.js
@@ -16,6 +16,7 @@ import {
   Calendar,
   Award
 } from 'lucide-react';
+import logService from '../services/logService';
 
 const GuestSignatureConfirmation = () => {
   const navigate = useNavigate();
@@ -38,7 +39,7 @@ const GuestSignatureConfirmation = () => {
         const data = await signatureService.getGuestEnvelope(envelopeId, token);
         setEnvelope(data);
       } catch (e) {
-        console.error(e);
+        logService.error(e);
         toast.error('Impossible de charger les informations du document');
       } finally {
         setLoadingEnv(false);
@@ -68,7 +69,7 @@ const GuestSignatureConfirmation = () => {
       window.URL.revokeObjectURL(url);
       toast.success('Document téléchargé avec succès');
     } catch (err) {
-      console.error('Erreur téléchargement document signé:', err);
+      logService.error('Erreur téléchargement document signé:', err);
       toast.error('Échec du téléchargement. Veuillez réessayer.');
     } finally {
       setDownloading(false);

--- a/frontend/src/pages/NotificationSettings.js
+++ b/frontend/src/pages/NotificationSettings.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { api } from '../services/apiUtils';
+import logService from '../services/logService';
 
 const NotificationSettings = () => {
   const [prefs, setPrefs] = useState({ email: true, sms: false, push: false });
@@ -15,7 +16,7 @@ const NotificationSettings = () => {
           setId(data[0].id);
         }
       } catch (err) {
-        console.error(err);
+        logService.error(err);
       }
     };
     fetchPrefs();

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -1,6 +1,7 @@
 // src/pages/ProfilePage.js
 import React, { useEffect, useState } from 'react';
 import { api, API_BASE_URL } from '../services/apiUtils';
+import logService from '../services/logService';
 import { 
   User, Mail, Calendar, Phone, MapPin, Upload, Eye, EyeOff, 
   Save, Lock, CheckCircle, XCircle, Camera, Edit3, Shield
@@ -40,7 +41,7 @@ const ProfilePage = () => {
           setAvatarPreview(`${API_BASE_URL}${res.data.avatar}`);
         }
       } catch (err) {
-        console.error(err);
+        logService.error(err);
       }
     };
     fetchProfile();

--- a/frontend/src/pages/QrVerifyPage.jsx
+++ b/frontend/src/pages/QrVerifyPage.jsx
@@ -9,6 +9,7 @@ import { Document, Page } from 'react-pdf';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 import signatureService from '../services/signatureService';
+import logService from '../services/logService';
 
 const LoadingSpinner = () => (
   <div className="flex items-center justify-center">
@@ -106,7 +107,7 @@ export default function QrVerifyPage() {
         const res = await signatureService.verifyQRCodeWithSig(uuid, sig);
         setData(res);
       } catch (e) {
-        console.error(e);
+        logService.error(e);
         setErr("Impossible de charger la preuve (QR non trouvé ou signature invalide).");
       } finally {
         setLoading(false);
@@ -129,7 +130,7 @@ export default function QrVerifyPage() {
         });
         setNumPages(0);
       } catch (e) {
-        console.error('PDF fetch error:', e);
+        logService.error('PDF fetch error:', e);
         setPdfUrl(null);
       } finally {
         setLoadingPdf(false);
@@ -322,7 +323,7 @@ export default function QrVerifyPage() {
                     key={uuid}
                     file={pdfUrl}
                     onLoadSuccess={({ numPages }) => setNumPages(numPages)}
-                    onLoadError={(err) => console.error('PDF error:', err)}
+                    onLoadError={(err) => logService.error('PDF error:', err)}
                     loading={<div className="p-6">Chargement PDF…</div>}
                   >
                     {Array.from({ length: numPages }, (_, i) => (

--- a/frontend/src/pages/SignatureConfirmation.js
+++ b/frontend/src/pages/SignatureConfirmation.js
@@ -15,6 +15,7 @@ import {
   Shield,
   ExternalLink
 } from 'lucide-react';
+import logService from '../services/logService';
 
 const SignatureConfirmation = () => {
   const navigate = useNavigate();
@@ -34,7 +35,7 @@ const SignatureConfirmation = () => {
         const data = await signatureService.getEnvelope(envelopeId);
         setEnvelope(data);
       } catch (e) {
-        console.error(e);
+        logService.error(e);
       } finally {
         setLoadingEnv(false);
       }
@@ -63,7 +64,7 @@ const SignatureConfirmation = () => {
       window.URL.revokeObjectURL(url);
       toast.success('Document téléchargé avec succès');
     } catch (err) {
-      console.error('Erreur téléchargement document signé:', err);
+      logService.error('Erreur téléchargement document signé:', err);
       toast.error('Échec du téléchargement. Veuillez réessayer.');
     } finally {
       setDownloading(false);

--- a/frontend/src/services/apiUtils.js
+++ b/frontend/src/services/apiUtils.js
@@ -2,6 +2,7 @@
 import axios from 'axios';
 import createAuthRefreshInterceptor from 'axios-auth-refresh';
 import { toast } from 'react-toastify';
+import logService from './logService';
 // URL de base de l'API Django
 export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
@@ -90,11 +91,11 @@ api.interceptors.response.use(
   error => {
     if (!error.response) {
         toast.error('Erreur réseau ou serveur injoignable');
-      console.error('Network error or backend unreachable');
+      logService.error('Network error or backend unreachable');
     } else if (error.response.status === 403) {
       console.warn('Access denied (403).');
     } else if (error.response.status >= 500) {
-      console.error('Server error:', error.response.data);
+      logService.error('Server error:', error.response.data);
     }
     return Promise.reject(error);
   }

--- a/frontend/src/services/logService.js
+++ b/frontend/src/services/logService.js
@@ -1,0 +1,21 @@
+const isDev = process.env.NODE_ENV === 'development';
+
+const log = (...args) => {
+  if (isDev) {
+    console.log(...args);
+  }
+};
+
+const warn = (...args) => {
+  if (isDev) {
+    console.warn(...args);
+  }
+};
+
+const error = (...args) => {
+  if (isDev) {
+    console.error(...args);
+  }
+};
+
+export default { log, warn, error };


### PR DESCRIPTION
## Summary
- add logService with log/warn/error helpers gated by NODE_ENV
- route component console.error calls through logService
- ensure user-facing toast errors remain unaffected

## Testing
- `NODE_ENV=production node --input-type=module -e "import('./frontend/src/services/logService.js').then(m=>{m.default.error('test');});"`
- `CI=true npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb5a5f5888333944b4d98b6813770