### PR TITLE
feat: add global loader and centralized error handling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,9 @@
 
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { useAuth } from './AuthContext';
-import { Routes, Route, Navigate, Outlet,useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom';
+import GlobalLoader from './components/GlobalLoader';
+import { setLoadingCallback } from './services/apiUtils';
 
 const DashboardSignature = React.lazy(() => import('./pages/DashboardSignature'));
 const DocumentDetail = React.lazy(() => import('./pages/DocumentDetail'));
@@ -45,6 +47,11 @@ const LoadingSpinner = () => (
 
 const App = () => {
   const { isLoading } = useAuth();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoadingCallback(setLoading);
+  }, []);
  
 
   // Afficher le spinner pendant le chargement de l'authentification
@@ -53,8 +60,10 @@ const App = () => {
   }
 
   return (
-    <Suspense fallback={<LoadingSpinner />}>
-      <Routes>
+    <>
+      <GlobalLoader loading={loading} />
+      <Suspense fallback={<LoadingSpinner />}>
+        <Routes>
       {/* ROUTES PUBLIQUES - À PLACER EN PREMIER ET DANS LE BON ORDRE */}
       
       {/* LOGIN */}
@@ -104,8 +113,9 @@ const App = () => {
       {/* Redirection par défaut - À PLACER EN DERNIER */}
       <Route path="/" element={<Navigate to="/dashboard" replace />} />
        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </Suspense>
+        </Routes>
+      </Suspense>
+    </>
   );
 };
 

--- a/frontend/src/components/GlobalLoader.js
+++ b/frontend/src/components/GlobalLoader.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const GlobalLoader = ({ loading }) => {
+  if (!loading) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30 z-50">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+    </div>
+  );
+};
+
+export default GlobalLoader;

--- a/frontend/src/services/signatureService.js
+++ b/frontend/src/services/signatureService.js
@@ -1,4 +1,5 @@
 import { api } from './apiUtils';
+import { toast } from 'react-toastify';
 
 const BASE = 'api/signature';
 
@@ -9,7 +10,11 @@ const apiRequest = async (method, url, data, config, errorMessage = 'Une erreur 
     const res = await api[m](...args);
     return res.data;
   } catch (err) {
-    throw new Error(errorMessage);
+    if (err.response && err.response.status < 500) {
+      toast.error(errorMessage);
+    }
+    err.message = errorMessage;
+    throw err;
   }
 };
 


### PR DESCRIPTION
## Summary
- show a full-screen loader during any axios call
- surface API errors with toasts from a single helper
- hook loader into app layout for automatic feedback

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68adc13f050083338672b855946b85a4