### PR TITLE
feat: enhance UX with empty state and confirmations

### DIFF
--- a/frontend/src/components/SentEnvelopes.js
+++ b/frontend/src/components/SentEnvelopes.js
@@ -68,12 +68,13 @@ const SentEnvelopes = () => {
           </Link>
           <button
             onClick={() => {
+              if (!window.confirm('Voulez-vous vraiment annuler cette enveloppe ?')) return;
               signatureService.cancelEnvelope(value)
                 .then(() => {
                   toast.success('Enveloppe annulée');
                   setEnvelopes(envelopes.filter(e => e.id !== value));
                 })
-                .catch(() => toast.error('Échec de l\'annulation'));
+                .catch(() => toast.error("Échec de l'annulation"));
             }}
             className="text-red-600 hover:text-red-800 text-sm"
           >

--- a/frontend/src/pages/DashboardSignature.js
+++ b/frontend/src/pages/DashboardSignature.js
@@ -250,88 +250,92 @@ const DashboardSignature = () => {
                   />
                 </div>
               </div>
-              <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Titre</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Statut</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Progression</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Signataires</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Créé le</th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Échéance</th>
-                      <th className="px-6 py-3"></th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-gray-200">
-                    {displayedDocuments.map(doc => (
-                      <tr key={doc.id}>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <p className="text-sm font-medium text-gray-900">{doc.title}</p>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          {/* Badge statut lisible */}
-                          {(['pending','sent'].includes(doc.status)) && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-                              En cours
-                            </span>
-                          )}
-                          {doc.status === 'completed' && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                              Terminé
-                            </span>
-                          )}
-                          {(!['pending','sent','completed'].includes(doc.status)) && (
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                              {String(doc.status).replace(/([A-Z])/g, ' $1')}
-                            </span>
-                          )}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          {/* Badge progression + barre */}
-                          <div className="flex items-center space-x-2 mb-1">
-                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                              {doc.signedBy}/{doc.signers} signés
-                            </span>
-                          </div>
-                          <div className="w-40 bg-gray-200 rounded-full h-2" title={`${doc.progress}%`}>
-                            <div
-                              className="h-2 rounded-full bg-blue-600"
-                              style={{ width: `${doc.progress}%` }}
-                              role="progressbar"
-                              aria-valuemin={0}
-                              aria-valuemax={100}
-                              aria-valuenow={Number(doc.progress)}
-                            />
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <p className="text-sm text-gray-500">{doc.signedBy}/{doc.signers}</p>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <p className="text-sm text-gray-500">{new Date(doc.createdAt).toLocaleDateString('fr-FR')}</p>
-                        </td>
-                         <td className="px-6 py-4 whitespace-nowrap">
-                          <p className="text-sm text-gray-500">
-                            {doc.deadline ? new Date(doc.deadline).toLocaleDateString('fr-FR') : '-'}
-                          </p>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
-                          <Eye
-                            className="inline-block w-5 h-5 cursor-pointer hover:text-blue-600"
-                            onClick={() => handlePreview(doc.id)}
-                          />
-                          <Download
-                            className="inline-block w-5 h-5 cursor-pointer hover:text-green-600"
-                            onClick={() => handleDownload(doc.id, doc.title)}
-                          />
-                          <Edit3 className="inline-block w-5 h-5 cursor-pointer hover:text-indigo-600" />
-                        </td>
+              {displayedDocuments.length === 0 ? (
+                <div className="p-6 text-center text-gray-500">Aucun document récent</div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Titre</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Statut</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Progression</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Signataires</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Créé le</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Échéance</th>
+                        <th className="px-6 py-3"></th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+                    </thead>
+                    <tbody className="bg-white divide-y divide-gray-200">
+                      {displayedDocuments.map(doc => (
+                        <tr key={doc.id}>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <p className="text-sm font-medium text-gray-900">{doc.title}</p>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            {/* Badge statut lisible */}
+                            {(['pending','sent'].includes(doc.status)) && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                                En cours
+                              </span>
+                            )}
+                            {doc.status === 'completed' && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                Terminé
+                              </span>
+                            )}
+                            {(!['pending','sent','completed'].includes(doc.status)) && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                {String(doc.status).replace(/([A-Z])/g, ' $1')}
+                              </span>
+                            )}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            {/* Badge progression + barre */}
+                            <div className="flex items-center space-x-2 mb-1">
+                              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                {doc.signedBy}/{doc.signers} signés
+                              </span>
+                            </div>
+                            <div className="w-40 bg-gray-200 rounded-full h-2" title={`${doc.progress}%`}>
+                              <div
+                                className="h-2 rounded-full bg-blue-600"
+                                style={{ width: `${doc.progress}%` }}
+                                role="progressbar"
+                                aria-valuemin={0}
+                                aria-valuemax={100}
+                                aria-valuenow={Number(doc.progress)}
+                              />
+                            </div>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <p className="text-sm text-gray-500">{doc.signedBy}/{doc.signers}</p>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <p className="text-sm text-gray-500">{new Date(doc.createdAt).toLocaleDateString('fr-FR')}</p>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <p className="text-sm text-gray-500">
+                              {doc.deadline ? new Date(doc.deadline).toLocaleDateString('fr-FR') : '-'}
+                            </p>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                            <Eye
+                              className="inline-block w-5 h-5 cursor-pointer hover:text-blue-600"
+                              onClick={() => handlePreview(doc.id)}
+                            />
+                            <Download
+                              className="inline-block w-5 h-5 cursor-pointer hover:text-green-600"
+                              onClick={() => handleDownload(doc.id, doc.title)}
+                            />
+                            <Edit3 className="inline-block w-5 h-5 cursor-pointer hover:text-indigo-600" />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
             </div>
           </div>
 

--- a/frontend/src/pages/SavedSignaturesPage.js
+++ b/frontend/src/pages/SavedSignaturesPage.js
@@ -61,6 +61,7 @@ const SavedSignaturesPage = () => {
   };
 
   const remove = async (id) => {
+    if (!window.confirm('Supprimer cette signature ?')) return;
     try {
       await signatureService.deleteSavedSignature(id);
       toast.success('Supprimé');


### PR DESCRIPTION
## Summary
- add cancellation confirmation for sent envelopes
- confirm before removing saved signatures
- show empty state when no recent documents on dashboard

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching bootstrap-icons)*

------
https://chatgpt.com/codex/tasks/task_e_68ade247ca0483339160c70d64edd49e