### PR TITLE
feat: centralize network error handling

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@
 import React, { Suspense } from 'react';
 import { useAuth } from './AuthContext';
 import { Routes, Route, Navigate, Outlet,useLocation } from 'react-router-dom';
+import LoadingSkeleton from './components/LoadingSkeleton';
 
 const DashboardSignature = React.lazy(() => import('./pages/DashboardSignature'));
 const DocumentDetail = React.lazy(() => import('./pages/DocumentDetail'));
@@ -37,23 +38,17 @@ const ProtectedRoute = () => {
 
 };
 
-const LoadingSpinner = () => (
-  <div className="min-h-screen flex items-center justify-center" data-testid="loading-spinner">
-    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-  </div>
-);
-
 const App = () => {
   const { isLoading } = useAuth();
  
 
-  // Afficher le spinner pendant le chargement de l'authentification
+  // Afficher le skeleton pendant le chargement de l'authentification
   if (isLoading) {
-    return <LoadingSpinner />;
+    return <LoadingSkeleton />;
   }
 
   return (
-    <Suspense fallback={<LoadingSpinner />}>
+    <Suspense fallback={<LoadingSkeleton />}> 
       <Routes>
       {/* ROUTES PUBLIQUES - À PLACER EN PREMIER ET DANS LE BON ORDRE */}
       

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -44,5 +44,5 @@ test.each(routes)('displays fallback while loading %s', (route) => {
       <App />
     </MemoryRouter>
   );
-  expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument();
 });

--- a/frontend/src/ErrorContext.js
+++ b/frontend/src/ErrorContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useRef, useCallback, useEffect } from 'react';
+import { toast } from 'react-toastify';
+import { setErrorCallback } from './services/apiUtils';
+
+const ErrorContext = createContext({ notifyError: () => {} });
+
+export const ErrorProvider = ({ children }) => {
+  const throttled = useRef(false);
+
+  const notifyError = useCallback((message) => {
+    if (throttled.current) return;
+    toast.error(message);
+    throttled.current = true;
+    setTimeout(() => {
+      throttled.current = false;
+    }, 3000);
+  }, []);
+
+  useEffect(() => {
+    setErrorCallback(notifyError);
+  }, [notifyError]);
+
+  return (
+    <ErrorContext.Provider value={{ notifyError }}>
+      {children}
+    </ErrorContext.Provider>
+  );
+};
+
+export const useError = () => useContext(ErrorContext);
+
+export default ErrorContext;

--- a/frontend/src/components/ErrorBoundary.js
+++ b/frontend/src/components/ErrorBoundary.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -12,18 +11,15 @@ class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    // You can log the error to an error reporting service here
+    // eslint-disable-next-line no-console
     console.error('ErrorBoundary caught an error', error, errorInfo);
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div className="h-screen flex flex-col items-center justify-center p-4 text-center">
-          <h1 className="text-2xl font-bold mb-4">Une erreur s'est produite</h1>
-          <Link to="/" className="text-blue-500 underline">
-            Retour à l'accueil
-          </Link>
+        <div className="min-h-screen flex items-center justify-center p-4">
+          <p className="text-red-600 text-center">Une erreur inattendue est survenue.</p>
         </div>
       );
     }

--- a/frontend/src/components/LoadingSkeleton.js
+++ b/frontend/src/components/LoadingSkeleton.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const LoadingSkeleton = () => (
+  <div className="min-h-screen flex items-center justify-center p-4" data-testid="loading-skeleton">
+    <div className="w-full max-w-sm space-y-4 animate-pulse">
+      <div className="h-4 bg-gray-300 rounded"></div>
+      <div className="h-4 bg-gray-300 rounded"></div>
+      <div className="h-4 bg-gray-300 rounded"></div>
+    </div>
+  </div>
+);
+
+export default LoadingSkeleton;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './AuthContext';
 import { pdfjs } from 'react-pdf';
 import ErrorBoundary from './components/ErrorBoundary';
+import { ErrorProvider } from './ErrorContext';
 import './index.css';
 
 
@@ -15,9 +16,11 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <BrowserRouter>
     <ErrorBoundary>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <ErrorProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ErrorProvider>
     </ErrorBoundary>
   </BrowserRouter>
 );

--- a/frontend/src/services/apiUtils.js
+++ b/frontend/src/services/apiUtils.js
@@ -1,7 +1,6 @@
 // src/servics/apiUtils.js
 import axios from 'axios';
 import createAuthRefreshInterceptor from 'axios-auth-refresh';
-import { toast } from 'react-toastify';
 import logService from './logService';
 // URL de base de l'API Django
 export const API_BASE_URL = process.env.REACT_APP_API_BASE_URL;
@@ -41,6 +40,12 @@ export const getCSRFToken = () => {
 let logoutCallback = null;
 export const setLogoutCallback = (cb) => {
   logoutCallback = cb;
+};
+
+// Callback global pour gérer les erreurs réseau
+let errorCallback = null;
+export const setErrorCallback = (cb) => {
+  errorCallback = cb;
 };
 
 // Logique de refresh à déclencher sur 401
@@ -93,7 +98,9 @@ api.interceptors.response.use(
   response => response,
   error => {
     if (!error.response) {
-        toast.error('Erreur réseau ou serveur injoignable');
+      if (errorCallback) {
+        errorCallback('Erreur réseau ou serveur injoignable');
+      }
       logService.error('Network error or backend unreachable');
     } else if (error.response.status === 403) {
       console.warn('Access denied (403).');

--- a/frontend/src/services/apiUtils.test.js
+++ b/frontend/src/services/apiUtils.test.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { api, setLogoutCallback } from './apiUtils';
+import { api, setLogoutCallback, setErrorCallback } from './apiUtils';
 
 describe('refresh failure handling', () => {
   const originalAdapter = api.defaults.adapter;
@@ -30,5 +30,23 @@ describe('refresh failure handling', () => {
     await expect(api.get('/protected')).rejects.toBeDefined();
 
     expect(navigate).toHaveBeenCalledWith('/login');
+  });
+});
+
+describe('network error handling', () => {
+  const originalAdapter = api.defaults.adapter;
+
+  afterEach(() => {
+    api.defaults.adapter = originalAdapter;
+  });
+
+  test('invokes global error callback on network error', async () => {
+    const errorCb = jest.fn();
+    setErrorCallback(errorCb);
+
+    api.defaults.adapter = () => Promise.reject({ request: {} });
+
+    await expect(api.get('/whatever')).rejects.toBeDefined();
+    expect(errorCb).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- route Axios network errors through a global ErrorContext with throttled toasts
- add ErrorBoundary wrapper and skeleton-based loading UI
- replace spinner fallback with consistent skeleton and tests for error handler

## Testing
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adf9ea920c8333a83609a480dbae5d