### PR TITLE
feat: improve keyboard navigation and focus

### DIFF
--- a/frontend/src/pages/BulkSignSameWizard.js
+++ b/frontend/src/pages/BulkSignSameWizard.js
@@ -1,5 +1,6 @@
 // src/pages/BulkSignSameWizard.js
 import React, { useEffect, useRef, useState, useLayoutEffect } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { Document, Page } from 'react-pdf';
 import { toast } from 'react-toastify';
 import { FiLayers, FiDownload, FiMove, FiFile, FiX } from 'react-icons/fi';
@@ -22,6 +23,8 @@ export default function BulkSignSameWizard() {
   const [viewerWidth, setViewerWidth] = useState(0);
   const pollingRef = useRef(null);
   const [isProcessing, setIsProcessing] = useState(false);
+
+  const titleRef = usePageTitleFocus();
 
   // ---- layout measure ----
   useLayoutEffect(() => {
@@ -116,7 +119,7 @@ export default function BulkSignSameWizard() {
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center">
             <FiLayers className="w-6 h-6 text-blue-600 mr-3" />
-            <h1 className="text-xl lg:text-2xl font-bold text-gray-800">Signature masse</h1>
+            <h1 ref={titleRef} tabIndex={-1} className="text-xl lg:text-2xl font-bold text-gray-800">Signature masse</h1>
           </div>
           {(files.length || sigFile || placement) ? (
             <button

--- a/frontend/src/pages/DashboardSignature.js
+++ b/frontend/src/pages/DashboardSignature.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { Link } from 'react-router-dom';
 import SignatureNavbar from '../components/SignatureNavbar';
 import signatureService from '../services/signatureService';
@@ -39,6 +40,8 @@ const DashboardSignature = () => {
   const [recentDocuments, setRecentDocuments] = useState([]);
   const [filter, setFilter] = useState('all');
   const [searchTerm, setSearchTerm] = useState('');
+
+  const titleRef = usePageTitleFocus();
 
   useEffect(() => {
     const loadData = async () => {
@@ -152,7 +155,7 @@ const DashboardSignature = () => {
       <main className="flex-1 bg-gray-50 p-4 sm:p-6 lg:px-8">
         {/* En-tête */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-4">
-          <h1 className="text-2xl font-semibold text-gray-900">Tableau de bord</h1>
+          <h1 ref={titleRef} tabIndex={-1} className="text-2xl font-semibold text-gray-900">Tableau de bord</h1>
           <Link
             to="/signature/new"
             className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"

--- a/frontend/src/pages/DocumentDetail.js
+++ b/frontend/src/pages/DocumentDetail.js
@@ -2,6 +2,8 @@
 // Version responsive avec sidebar mobile et meilleure adaptation
 
 import React, { useEffect, useState, useCallback, useLayoutEffect, useRef } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
+import { handleKeyDown } from '../utils/keyboard';
 import { useParams, Link } from 'react-router-dom';
 import { Document, Page } from 'react-pdf';
 import { FiMenu, FiX, FiDownload, FiExternalLink, FiArrowLeft, FiClock } from 'react-icons/fi';
@@ -18,7 +20,13 @@ function ReminderModal({ open, count, onClose }) {
   
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => handleKeyDown(e, onClose, onClose)}
+      />
       <div className="relative bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6">
         <div className="flex items-center gap-3 mb-3">
           <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
@@ -50,6 +58,8 @@ function ReminderModal({ open, count, onClose }) {
 
 const DocumentDetail = () => {
   const { id } = useParams();
+
+  const titleRef = usePageTitleFocus();
 
   // État principal
   const [env, setEnv] = useState(null);
@@ -242,7 +252,7 @@ const DocumentDetail = () => {
         >
           <FiMenu className="w-5 h-5" />
         </button>
-        <h1 className="font-semibold text-gray-900 truncate mx-4 flex-1">{env.title}</h1>
+        <h1 ref={titleRef} tabIndex={-1} className="font-semibold text-gray-900 truncate mx-4 flex-1">{env.title}</h1>
         <div className="flex space-x-2">
           <button
             onClick={handlePreview}

--- a/frontend/src/pages/DocumentSign.js
+++ b/frontend/src/pages/DocumentSign.js
@@ -4,6 +4,7 @@
 // MISE À JOUR: Redirection selon le type d'utilisateur
 
 import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { Document, Page, pdfjs } from 'react-pdf';
@@ -45,6 +46,8 @@ const DocumentSign = () => {
       if (ro) ro.disconnect();
     };
   }, []);
+
+  const titleRef = usePageTitleFocus();
 
   // données
   const [loading, setLoading] = useState(true);
@@ -512,7 +515,7 @@ async function urlToDataUrl(url) {
     <div className="flex h-screen">
       {/* sidebar */}
       <div className="w-80 bg-white border-r p-6 overflow-auto">
-        <h1 className="text-2xl font-bold mb-4">
+        <h1 ref={titleRef} tabIndex={-1} className="text-2xl font-bold mb-4">
         {isAlreadySigned ? 'Document déjà signé :' : 'Signer le document :'} {sanitize(envelope.title)}
         </h1>
 

--- a/frontend/src/pages/DocumentUpload.js
+++ b/frontend/src/pages/DocumentUpload.js
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import React, { useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
 import { FiUpload, FiFileText } from 'react-icons/fi';
@@ -11,6 +12,8 @@ const DocumentUpload = () => {
   const [title, setTitle] = useState('');
   const [errors, setErrors] = useState({});
   const navigate = useNavigate();
+
+  const titleRef = usePageTitleFocus();
 
   const handleFileChange = async (e) => {
     const selectedFiles = Array.from(e.target.files);
@@ -61,7 +64,7 @@ const DocumentUpload = () => {
   return (
     <div className="max-w-2xl mx-auto px-6 py-10">
       <div className="bg-white rounded-lg shadow-lg p-6">
-        <h1 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-2">
+        <h1 ref={titleRef} tabIndex={-1} className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-2">
           <FiFileText className="text-blue-500" />
           Téléverser un document
         </h1>

--- a/frontend/src/pages/DocumentWorkflow.js
+++ b/frontend/src/pages/DocumentWorkflow.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Document, Page, pdfjs } from 'react-pdf';
 import signatureService from '../services/signatureService';
@@ -20,6 +21,8 @@ export default function DocumentWorkflow() {
   const [deadlineMode, setDeadlineMode] = useState('days'); // 'days' | 'exact'
   const [deadlineDays, setDeadlineDays] = useState(7);
   const [deadlineExact, setDeadlineExact] = useState('');   // 'YYYY-MM-DDTHH:mm' (local)
+
+  const titleRef = usePageTitleFocus();
 
   const [documents, setDocuments] = useState([]);
   const [selectedDocId, setSelectedDocId] = useState(null);
@@ -403,7 +406,7 @@ const selectDocument = useCallback(async (doc) => {
       <div className="w-80 bg-white shadow-lg overflow-y-auto border-r border-gray-200">
         <div className="p-6">
           <div className="flex items-center justify-between mb-6">
-            <h2 className="text-xl font-bold text-gray-900">Destinataires</h2>
+            <h2 ref={titleRef} tabIndex={-1} className="text-xl font-bold text-gray-900">Destinataires</h2>
             <div className="text-sm text-gray-500">
               {recipients.length} signataire{recipients.length > 1 ? 's' : ''}
             </div>

--- a/frontend/src/pages/EnvelopeSent.js
+++ b/frontend/src/pages/EnvelopeSent.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { useParams, useNavigate } from 'react-router-dom';
 import signatureService from '../services/signatureService';
 import SignatureNavbar from '../components/SignatureNavbar';
@@ -22,6 +23,8 @@ export default function EnvelopeSent() {
   const navigate = useNavigate();
   const [envelope, setEnvelope] = useState(null);
   const [loading, setLoading] = useState(true);
+
+  const titleRef = usePageTitleFocus();
 
   useEffect(() => {
     const loadEnvelope = async () => {
@@ -110,7 +113,7 @@ export default function EnvelopeSent() {
           
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
-              <h1 className="text-2xl lg:text-3xl font-bold text-gray-900 mb-2">
+              <h1 ref={titleRef} tabIndex={-1} className="text-2xl lg:text-3xl font-bold text-gray-900 mb-2">
                 Document envoyé avec succès !
               </h1>
               <p className="text-gray-600">

--- a/frontend/src/pages/GuestSignatureConfirmation.js
+++ b/frontend/src/pages/GuestSignatureConfirmation.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import signatureService from '../services/signatureService';
@@ -25,6 +26,8 @@ const GuestSignatureConfirmation = () => {
   const [downloading, setDownloading] = useState(false);
   const [envelope, setEnvelope] = useState(null);
   const [loadingEnv, setLoadingEnv] = useState(true);
+
+  const titleRef = usePageTitleFocus();
 
   const envelopeId = location.state?.id || searchParams.get('id');
   const token = searchParams.get('token');
@@ -120,7 +123,7 @@ const GuestSignatureConfirmation = () => {
               </div>
             </div>
             <div className="mt-6">
-              <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 mb-3">
+              <h1 ref={titleRef} tabIndex={-1} className="text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 mb-3">
                 Signature réussie !
               </h1>
               <p className="text-lg sm:text-xl text-gray-600 max-w-2xl mx-auto">

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -1,5 +1,6 @@
 // src/pages/LoginPage.js
 import React, { useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { useAuth } from '../AuthContext';
 import { useLocation, Link } from 'react-router-dom';
 import { Eye, EyeOff, Mail, Lock, CheckCircle, XCircle, Loader2 } from 'lucide-react';
@@ -16,6 +17,8 @@ const LoginPage = () => {
   const [errors, setErrors] = useState({});
   const [showPassword, setShowPassword] = useState(false);
   const isFormValid = loginSchema.isValidSync({ username, password });
+
+  const titleRef = usePageTitleFocus();
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -46,7 +49,7 @@ const LoginPage = () => {
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-xl flex items-center justify-center">
             <Lock className="h-6 w-6 text-white" />
           </div>
-          <h2 className="mt-6 text-3xl font-bold tracking-tight text-gray-900">
+          <h2 ref={titleRef} tabIndex={-1} className="mt-6 text-3xl font-bold tracking-tight text-gray-900">
             Connexion
           </h2>
           <p className="mt-2 text-sm text-gray-600">

--- a/frontend/src/pages/NotFound.js
+++ b/frontend/src/pages/NotFound.js
@@ -1,16 +1,20 @@
 // src/pages/NotFound.js
 
 import React from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { Link } from 'react-router-dom';
 
-const NotFound = () => (
-  <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
-    <h1 className="text-4xl font-bold text-gray-800 mb-4">404 - Page non trouvée</h1>
-    <p className="text-gray-600 mb-6">La page que vous cherchez n'existe pas.</p>
-    <Link to="/" className="text-blue-600 hover:text-blue-800 underline">
-      Retour à l'accueil
-    </Link>
-  </div>
-);
+const NotFound = () => {
+  const titleRef = usePageTitleFocus();
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50">
+      <h1 ref={titleRef} tabIndex={-1} className="text-4xl font-bold text-gray-800 mb-4">404 - Page non trouvée</h1>
+      <p className="text-gray-600 mb-6">La page que vous cherchez n'existe pas.</p>
+      <Link to="/" className="text-blue-600 hover:text-blue-800 underline">
+        Retour à l'accueil
+      </Link>
+    </div>
+  );
+};
 
 export default NotFound;

--- a/frontend/src/pages/NotificationSettings.js
+++ b/frontend/src/pages/NotificationSettings.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { api } from '../services/apiUtils';
 import logService from '../services/logService';
 import { notificationSettingsSchema } from '../validation/schemas';
@@ -9,6 +10,8 @@ const NotificationSettings = () => {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const isValid = notificationSettingsSchema.isValidSync(prefs);
+
+  const titleRef = usePageTitleFocus();
 
   useEffect(() => {
     const fetchPrefs = async () => {
@@ -56,7 +59,7 @@ const NotificationSettings = () => {
 
   return (
     <div className="p-8">
-      <h2 className="text-2xl font-bold mb-6">Notifications</h2>
+      <h2 ref={titleRef} tabIndex={-1} className="text-2xl font-bold mb-6">Notifications</h2>
       {message && <div className="mb-4">{message}</div>}
       <form onSubmit={handleSubmit} className="space-y-4">
         <label className="flex items-center">

--- a/frontend/src/pages/PasswordResetPage.js
+++ b/frontend/src/pages/PasswordResetPage.js
@@ -1,5 +1,6 @@
 // src/pages/PasswordResetPage.js
 import React, { useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { Link } from 'react-router-dom';
 import { api } from '../services/apiUtils';
 import { Mail, ArrowLeft, CheckCircle, XCircle, Send, Loader2 } from 'lucide-react';
@@ -12,6 +13,8 @@ const PasswordResetPage = () => {
   const [isSuccess, setIsSuccess] = useState(false);
   const [errors, setErrors] = useState({});
   const isValid = passwordResetSchema.isValidSync({ email });
+
+  const titleRef = usePageTitleFocus();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -45,7 +48,7 @@ const PasswordResetPage = () => {
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-xl flex items-center justify-center">
             <Mail className="h-6 w-6 text-white" />
           </div>
-          <h2 className="mt-6 text-3xl font-bold tracking-tight text-gray-900">
+          <h2 ref={titleRef} tabIndex={-1} className="mt-6 text-3xl font-bold tracking-tight text-gray-900">
             Mot de passe oublié
           </h2>
           <p className="mt-2 text-sm text-gray-600">

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -1,5 +1,7 @@
 // src/pages/ProfilePage.js
 import React, { useEffect, useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
+import { handleKeyDown } from '../utils/keyboard';
 import { api, API_BASE_URL } from '../services/apiUtils';
 import logService from '../services/logService';
 import {
@@ -36,6 +38,8 @@ const ProfilePage = () => {
   const [activeTab, setActiveTab] = useState('profile');
   const isProfileValid = profileSchema.isValidSync(profile);
   const isPwdValid = passwordChangeSchema.isValidSync(passwordData);
+
+  const titleRef = usePageTitleFocus();
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -163,7 +167,7 @@ const ProfilePage = () => {
                 </div>
               </div>
               <div className="flex-1">
-                <h1 className="text-2xl font-bold text-white">
+                <h1 ref={titleRef} tabIndex={-1} className="text-2xl font-bold text-white">
                   {profile.first_name && profile.last_name 
                     ? `${profile.first_name} ${profile.last_name}` 
                     : profile.username}
@@ -178,6 +182,7 @@ const ProfilePage = () => {
             <nav className="flex px-6">
               <button
                 onClick={() => setActiveTab('profile')}
+                onKeyDown={(e) => handleKeyDown(e, () => setActiveTab('profile'))}
                 className={`py-4 px-6 text-sm font-medium border-b-2 transition-colors ${
                   activeTab === 'profile'
                     ? 'border-blue-500 text-blue-600'
@@ -189,6 +194,7 @@ const ProfilePage = () => {
               </button>
               <button
                 onClick={() => setActiveTab('password')}
+                onKeyDown={(e) => handleKeyDown(e, () => setActiveTab('password'), () => setActiveTab('profile'))}
                 className={`py-4 px-6 text-sm font-medium border-b-2 transition-colors ${
                   activeTab === 'password'
                     ? 'border-blue-500 text-blue-600'

--- a/frontend/src/pages/QrVerifyPage.jsx
+++ b/frontend/src/pages/QrVerifyPage.jsx
@@ -1,5 +1,6 @@
 // QrVerifyPage.jsx
 import React, { useEffect, useState, useLayoutEffect, useRef } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import {
   CheckCircle, AlertTriangle, FileText, Shield, Calendar,
   User, Hash, ExternalLink, Info, Mail
@@ -64,6 +65,7 @@ export default function QrVerifyPage() {
   const [numPages, setNumPages] = useState(0);
   const viewerRef = useRef(null);
   const [contentWidth, setContentWidth] = useState(0);
+  const titleRef = usePageTitleFocus();
   // Mesure responsive du conteneur PDF
   useLayoutEffect(() => {
   const el = viewerRef.current;
@@ -186,7 +188,7 @@ export default function QrVerifyPage() {
             <FileText className="w-6 h-6 text-purple-600" />
           </div>
           <div className="flex-1">
-            <h1 className="text-2xl font-bold text-gray-900">
+            <h1 ref={titleRef} tabIndex={-1} className="text-2xl font-bold text-gray-900">
               {data?.title || 'Document'}
             </h1>
             <p className="text-sm text-gray-500 mt-1">

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -1,5 +1,6 @@
 // src/pages/RegisterPage.js
 import React, { useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { Link } from 'react-router-dom';
 import { api } from '../services/apiUtils';
 import {
@@ -31,6 +32,8 @@ const RegisterPage = () => {
   const [avatarPreview, setAvatarPreview] = useState(null);
   const isStep1Valid = registerStep1Schema.isValidSync(form);
   const isStep2Valid = registerStep2Schema.isValidSync(form);
+
+  const titleRef = usePageTitleFocus();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -112,7 +115,7 @@ const RegisterPage = () => {
             <div className="mx-auto h-16 w-16 bg-green-500 rounded-full flex items-center justify-center mb-6">
               <CheckCircle className="h-8 w-8 text-white" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            <h2 ref={titleRef} tabIndex={-1} className="text-2xl font-bold text-gray-900 mb-4">
               Inscription réussie !
             </h2>
             <p className="text-gray-600 mb-6">
@@ -145,7 +148,7 @@ const RegisterPage = () => {
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-xl flex items-center justify-center">
             <UserPlus className="h-6 w-6 text-white" />
           </div>
-          <h2 className="mt-6 text-3xl font-bold tracking-tight text-gray-900">
+          <h2 ref={titleRef} tabIndex={-1} className="mt-6 text-3xl font-bold tracking-tight text-gray-900">
             Créer un compte
           </h2>
           <p className="mt-2 text-sm text-gray-600">

--- a/frontend/src/pages/SavedSignaturesPage.js
+++ b/frontend/src/pages/SavedSignaturesPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import SignaturePadComponent from '../components/SignaturePadComponent';
 import signatureService from '../services/signatureService';
 import { toast } from 'react-toastify';
@@ -15,6 +16,8 @@ const SavedSignaturesPage = () => {
   const [items, setItems] = useState([]);
   const [drawData, setDrawData] = useState('');
   const [uploading, setUploading] = useState(false);
+
+  const titleRef = usePageTitleFocus();
 
   const load = async () => {
     try {
@@ -73,7 +76,7 @@ const SavedSignaturesPage = () => {
 
   return (
     <div className="p-6 max-w-4xl mx-auto space-y-6">
-      <h1 className="text-2xl font-semibold">Mes signatures enregistrées</h1>
+      <h1 ref={titleRef} tabIndex={-1} className="text-2xl font-semibold">Mes signatures enregistrées</h1>
 
       <div className="grid grid-cols-2 gap-4">
         <div>

--- a/frontend/src/pages/SelfSignWizard.js
+++ b/frontend/src/pages/SelfSignWizard.js
@@ -1,5 +1,7 @@
 // src/pages/SelfSignWizard.js
 import React, { useEffect, useRef, useState, useLayoutEffect } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
+import { handleKeyDown } from '../utils/keyboard';
 import { Document, Page } from 'react-pdf';
 import { toast } from 'react-toastify';
 import { FiUpload, FiX, FiEdit3, FiMenu, FiCheck } from 'react-icons/fi';
@@ -104,6 +106,8 @@ export default function SelfSignWizard() {
   // Option QR (checkbox)
   const [includeQr, setIncludeQr] = useState(true);
 
+  const titleRef = usePageTitleFocus();
+
   /* layout + responsive width (mesure unique) */
   useLayoutEffect(() => {
     const measure = () => setViewerWidth(viewerRef.current?.clientWidth || 600);
@@ -192,7 +196,7 @@ export default function SelfSignWizard() {
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-emerald-100 rounded-lg"><FiEdit3 className="w-5 h-5 text-emerald-600" /></div>
-            <h1 className="text-lg md:text-xl font-bold text-gray-900">Auto-signature</h1>
+            <h1 ref={titleRef} tabIndex={-1} className="text-lg md:text-xl font-bold text-gray-900">Auto-signature</h1>
           </div>
           {isMobile && <button onClick={() => setSidebarOpen(false)} className="p-2 hover:bg-gray-100 rounded-lg"><FiX className="w-5 h-5" /></button>}
         </div>
@@ -323,7 +327,15 @@ export default function SelfSignWizard() {
 
       {/* Sidebar */}
       <div className={`${isMobile ? `fixed inset-y-0 left-0 z-40 w-80 transform transition-transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}` : 'w-1/3'} bg-white border-r border-gray-200 flex flex-col`}>
-        {isMobile && sidebarOpen && <div className="fixed inset-0 bg-black/50 z-30" onClick={() => setSidebarOpen(false)} />}
+        {isMobile && sidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black/50 z-30"
+            onClick={() => setSidebarOpen(false)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => handleKeyDown(e, () => setSidebarOpen(false), () => setSidebarOpen(false))}
+          />
+        )}
         <div className="relative z-40 bg-white h-full flex flex-col"><Sidebar /></div>
       </div>
 
@@ -360,7 +372,11 @@ export default function SelfSignWizard() {
                     <div key={i} className="relative mb-6 bg-white shadow-lg rounded-lg overflow-hidden">
                       <Page pageNumber={i + 1} width={pageWidth} renderTextLayer={false} onLoadSuccess={(p) => onPageLoad(i + 1, p)} className="mx-auto" />
                       {pageDims[i + 1] && (
-                        <div onClick={(e) => handleOverlayClick(e, i + 1)}
+                        <div
+                             onClick={(e) => handleOverlayClick(e, i + 1)}
+                             role="button"
+                             tabIndex={0}
+                             onKeyDown={(e) => handleKeyDown(e, (ev) => handleOverlayClick(ev, i + 1), () => setPlacing(false))}
                              className="absolute top-0 left-1/2 -translate-x-1/2"
                              style={{ width: pageWidth, height: pageDims[i + 1].height * scale, cursor: placing ? 'crosshair' : 'default', zIndex: 10, backgroundColor: placing ? 'rgba(16,185,129,.08)' : 'transparent' }} />
                       )}

--- a/frontend/src/pages/SignatureConfirmation.js
+++ b/frontend/src/pages/SignatureConfirmation.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import signatureService from '../services/signatureService';
@@ -25,6 +26,8 @@ const SignatureConfirmation = () => {
   const [countdown, setCountdown] = useState(10);
   const [envelope, setEnvelope] = useState(null);
   const [loadingEnv, setLoadingEnv] = useState(true);
+
+  const titleRef = usePageTitleFocus();
 
   const envelopeId = location.state?.id || searchParams.get('id');
 
@@ -101,7 +104,7 @@ const SignatureConfirmation = () => {
               </div>
             </div>
             <div className="mt-4">
-              <h1 className="text-3xl lg:text-4xl font-bold text-gray-900 mb-2">
+              <h1 ref={titleRef} tabIndex={-1} className="text-3xl lg:text-4xl font-bold text-gray-900 mb-2">
                 Signature confirmée !
               </h1>
               <p className="text-lg text-gray-600">

--- a/frontend/src/pages/SignatureLayout.js
+++ b/frontend/src/pages/SignatureLayout.js
@@ -2,6 +2,7 @@
 // Version responsive avec sidebar mobile
 
 import React, { useState, useEffect } from 'react';
+import usePageTitleFocus from '../utils/usePageTitleFocus';
 import { Outlet, NavLink, useLocation } from 'react-router-dom';
 import { FiMenu, FiX } from 'react-icons/fi';
 import SignatureNavbar from '../components/SignatureNavbar';
@@ -9,6 +10,8 @@ import SignatureNavbar from '../components/SignatureNavbar';
 const SignatureLayout = () => {
   const location = useLocation();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const titleRef = usePageTitleFocus();
 
   // Fermer sidebar quand la route change (mobile)
   useEffect(() => {
@@ -44,7 +47,7 @@ const SignatureLayout = () => {
         >
           <FiMenu className="w-5 h-5" />
         </button>
-        <h1 className="font-semibold text-gray-900">Signatures</h1>
+        <h1 ref={titleRef} tabIndex={-1} className="font-semibold text-gray-900">Signatures</h1>
         <div className="w-9"> {/* Spacer pour centrer le titre */}</div>
       </div>
 

--- a/frontend/src/utils/keyboard.js
+++ b/frontend/src/utils/keyboard.js
@@ -1,0 +1,9 @@
+export function handleKeyDown(e, onEnter, onEscape) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    onEnter && onEnter(e);
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    onEscape && onEscape(e);
+  }
+}

--- a/frontend/src/utils/usePageTitleFocus.js
+++ b/frontend/src/utils/usePageTitleFocus.js
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export default function usePageTitleFocus() {
+  const titleRef = useRef(null);
+  useEffect(() => {
+    if (titleRef.current) {
+      titleRef.current.focus();
+    }
+  }, []);
+  return titleRef;
+}


### PR DESCRIPTION
## Summary
- add keyboard helper and page title focus hook
- apply focus handling to page headers
- enable Enter and Escape keyboard support on interactive elements

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: canvas build requires missing system dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68adf9dfc1748333baaf752f7cfcb971