### PR TITLE
feat: add keyboard action hook for forms and modals

### DIFF
--- a/frontend/src/hooks/useKeyboardActions.js
+++ b/frontend/src/hooks/useKeyboardActions.js
@@ -1,0 +1,17 @@
+import { useCallback } from 'react';
+
+export default function useKeyboardActions({ onEnter, onEsc }) {
+  return useCallback(
+    (e) => {
+      if (e.key === 'Enter' && onEnter) {
+        e.preventDefault();
+        onEnter(e);
+      } else if (e.key === 'Escape' && onEsc) {
+        e.preventDefault();
+        onEsc(e);
+      }
+    },
+    [onEnter, onEsc]
+  );
+}
+

--- a/frontend/src/pages/DocumentDetail.js
+++ b/frontend/src/pages/DocumentDetail.js
@@ -12,10 +12,12 @@ import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 import logService from '../services/logService';
 import useFocusTrap from '../hooks/useFocusTrap';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 function ReminderModal({ open, count, onClose }) {
   const dialogRef = useRef(null);
   useFocusTrap(dialogRef, open);
+  const handleKeyDown = useKeyboardActions({ onEnter: onClose, onEsc: onClose });
 
   if (!open) return null;
   const has = (count ?? 0) > 0;
@@ -28,6 +30,7 @@ function ReminderModal({ open, count, onClose }) {
         className="relative bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6"
         role="dialog"
         aria-modal="true"
+        onKeyDown={handleKeyDown}
       >
         <div className="flex items-center gap-3 mb-3">
           <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
@@ -47,6 +50,7 @@ function ReminderModal({ open, count, onClose }) {
         <div className="flex justify-end">
           <button
             onClick={onClose}
+            onKeyDown={(e) => e.key === 'Enter' && onClose(e)}
             className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700"
           >
             OK

--- a/frontend/src/pages/DocumentSign.js
+++ b/frontend/src/pages/DocumentSign.js
@@ -17,6 +17,7 @@ import sanitize from '../utils/sanitize';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 import useFocusTrap from '../hooks/useFocusTrap';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 
 const DocumentSign = () => {
@@ -347,15 +348,10 @@ async function urlToDataUrl(url) {
 
   useFocusTrap(modalRef, modalOpen);
 
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === 'Escape') closeModal();
-    };
-    if (modalOpen) {
-      document.addEventListener('keydown', handleKeyDown);
-    }
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [modalOpen]);
+  const modalKeyDown = useKeyboardActions({
+    onEnter: handleModalConfirm,
+    onEsc: closeModal,
+  });
 
   // peut-on signer ?
   const canSign = () => {
@@ -641,6 +637,7 @@ async function urlToDataUrl(url) {
           }
         }}
       >
+        <div onKeyDown={modalKeyDown}>
         <h2 className="text-lg font-semibold mb-3">Ajouter une signature</h2>
 
         <div className="flex items-center gap-4 mb-3">
@@ -771,12 +768,21 @@ async function urlToDataUrl(url) {
         )}
 
         <div className="mt-4 flex justify-end gap-2">
-          <button onClick={closeModal} className="px-4 py-2 rounded bg-gray-200">
+          <button
+            onClick={closeModal}
+            className="px-4 py-2 rounded bg-gray-200"
+            onKeyDown={(e) => e.key === 'Enter' && closeModal(e)}
+          >
             Annuler
           </button>
-          <button onClick={handleModalConfirm} className="px-4 py-2 rounded bg-green-600 text-white">
+          <button
+            onClick={handleModalConfirm}
+            onKeyDown={(e) => e.key === 'Enter' && handleModalConfirm(e)}
+            className="px-4 py-2 rounded bg-green-600 text-white"
+          >
             Valider
           </button>
+        </div>
         </div>
       </Modal>
     </div>

--- a/frontend/src/pages/DocumentUpload.js
+++ b/frontend/src/pages/DocumentUpload.js
@@ -5,12 +5,15 @@ import { toast } from 'react-toastify';
 import { FiUpload, FiFileText } from 'react-icons/fi';
 import logService from '../services/logService';
 import { documentUploadSchema } from '../validation/schemas';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 const DocumentUpload = () => {
   const [files, setFiles] = useState([]);
   const [title, setTitle] = useState('');
   const [errors, setErrors] = useState({});
   const navigate = useNavigate();
+
+  const handleKeyDown = useKeyboardActions({ onEnter: handleSubmit });
 
   const handleFileChange = async (e) => {
     const selectedFiles = Array.from(e.target.files);
@@ -66,7 +69,7 @@ const DocumentUpload = () => {
           Téléverser un document
         </h1>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
+        <form onSubmit={handleSubmit} onKeyDown={handleKeyDown} className="space-y-5">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Titre du document</label>
             <input

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -4,6 +4,7 @@ import { useAuth } from '../AuthContext';
 import { useLocation, Link } from 'react-router-dom';
 import { Eye, EyeOff, Mail, Lock, CheckCircle, XCircle, Loader2 } from 'lucide-react';
 import { loginSchema } from '../validation/schemas';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 const LoginPage = () => {
   const { login, authLoading } = useAuth();
@@ -16,6 +17,8 @@ const LoginPage = () => {
   const [errors, setErrors] = useState({});
   const [showPassword, setShowPassword] = useState(false);
   const isFormValid = loginSchema.isValidSync({ username, password });
+
+  const handleKeyDown = useKeyboardActions({ onEnter: handleLogin });
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -88,7 +91,7 @@ const LoginPage = () => {
             </div>
           )}
 
-          <form onSubmit={handleLogin} className="space-y-6">
+          <form onSubmit={handleLogin} onKeyDown={handleKeyDown} className="space-y-6">
             {/* Nom d'utilisateur */}
             <div>
               <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-2">

--- a/frontend/src/pages/NotificationSettings.js
+++ b/frontend/src/pages/NotificationSettings.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { api } from '../services/apiUtils';
 import logService from '../services/logService';
 import { notificationSettingsSchema } from '../validation/schemas';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 const NotificationSettings = () => {
   const [prefs, setPrefs] = useState({ email: true, sms: false, push: false });
@@ -9,6 +10,8 @@ const NotificationSettings = () => {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const isValid = notificationSettingsSchema.isValidSync(prefs);
+
+  const handleKeyDown = useKeyboardActions({ onEnter: handleSubmit });
 
   useEffect(() => {
     const fetchPrefs = async () => {
@@ -58,7 +61,7 @@ const NotificationSettings = () => {
     <div className="p-8">
       <h2 className="text-2xl font-bold mb-6">Notifications</h2>
       {message && <div className="mb-4">{message}</div>}
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} onKeyDown={handleKeyDown} className="space-y-4">
         <label className="flex items-center">
           <input type="checkbox" name="email" checked={prefs.email} onChange={handleChange} className="mr-2" />
           Email

--- a/frontend/src/pages/PasswordResetPage.js
+++ b/frontend/src/pages/PasswordResetPage.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { api } from '../services/apiUtils';
 import { Mail, ArrowLeft, CheckCircle, XCircle, Send, Loader2 } from 'lucide-react';
 import { passwordResetSchema } from '../validation/schemas';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 const PasswordResetPage = () => {
   const [email, setEmail] = useState('');
@@ -12,6 +13,8 @@ const PasswordResetPage = () => {
   const [isSuccess, setIsSuccess] = useState(false);
   const [errors, setErrors] = useState({});
   const isValid = passwordResetSchema.isValidSync({ email });
+
+  const handleKeyDown = useKeyboardActions({ onEnter: handleSubmit });
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -83,7 +86,7 @@ const PasswordResetPage = () => {
             </div>
           )}
 
-          <form onSubmit={handleSubmit} className="space-y-6">
+          <form onSubmit={handleSubmit} onKeyDown={handleKeyDown} className="space-y-6">
             {/* Email */}
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -7,6 +7,7 @@ import {
   Save, Lock, CheckCircle, XCircle, Camera, Edit3, Shield
 } from 'lucide-react';
 import { profileSchema, passwordChangeSchema } from '../validation/schemas';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 const ProfilePage = () => {
   const [profile, setProfile] = useState({
@@ -139,6 +140,9 @@ const ProfilePage = () => {
     }
   };
 
+  const profileKeyDown = useKeyboardActions({ onEnter: handleSubmit });
+  const pwdKeyDown = useKeyboardActions({ onEnter: handlePasswordSubmit });
+
   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -230,7 +234,7 @@ const ProfilePage = () => {
               </div>
             )}
 
-            <form onSubmit={handleSubmit} className="space-y-6" encType="multipart/form-data">
+            <form onSubmit={handleSubmit} onKeyDown={profileKeyDown} className="space-y-6" encType="multipart/form-data">
               {/* Photo de profil */}
               <div className="flex items-center space-x-6">
                 <div className="flex-shrink-0">
@@ -461,7 +465,7 @@ const ProfilePage = () => {
               </div>
             )}
 
-            <form onSubmit={handlePasswordSubmit} className="space-y-6">
+            <form onSubmit={handlePasswordSubmit} onKeyDown={pwdKeyDown} className="space-y-6">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Mot de passe actuel

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -8,6 +8,7 @@ import {
   Check
 } from 'lucide-react';
 import { registerStep1Schema, registerStep2Schema } from '../validation/schemas';
+import useKeyboardActions from '../hooks/useKeyboardActions';
 
 const RegisterPage = () => {
   const [form, setForm] = useState({
@@ -103,6 +104,16 @@ const RegisterPage = () => {
       setIsLoading(false);
     }
   };
+
+  const handleKeyDown = useKeyboardActions({
+    onEnter: (e) => {
+      if (currentStep === 1) {
+        handleNext(e);
+      } else {
+        handleSubmit(e);
+      }
+    }
+  });
 
   if (success) {
     return (
@@ -201,7 +212,7 @@ const RegisterPage = () => {
             </div>
           )}
 
-          <form onSubmit={handleSubmit} encType="multipart/form-data">
+          <form onSubmit={handleSubmit} onKeyDown={handleKeyDown} encType="multipart/form-data">
             {currentStep === 1 && (
               <div className="space-y-6">
                 <h3 className="text-lg font-medium text-gray-900 mb-4">Informations de connexion</h3>
@@ -298,6 +309,7 @@ const RegisterPage = () => {
                     type="button"
                     onClick={handleNext}
                     disabled={!isStep1Valid}
+                    onKeyDown={(e) => e.key === 'Enter' && handleNext(e)}
                     className="inline-flex items-center px-6 py-3 border border-transparent text-sm font-medium rounded-xl text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Suivant


### PR DESCRIPTION
## Summary
- add `useKeyboardActions` hook to handle Enter and Escape keys
- wire keyboard actions to forms and modal dialogs for better accessibility
- ensure primary buttons respond to keyboard input

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: canvas build error)*

------
https://chatgpt.com/codex/tasks/task_e_68adffc56ca88333b9d78223fe1a18d6