### PR TITLE
feat: add undo/redo and retina canvas for signature pad

### DIFF
--- a/frontend/src/components/SignaturePadComponent.js
+++ b/frontend/src/components/SignaturePadComponent.js
@@ -1,15 +1,25 @@
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
 import SignatureCanvas from 'react-signature-canvas';
 import logService from '../services/logService';
 
 const SignaturePadComponent = ({ onEnd, onChange, initialValue, canvasProps }) => {
   const sigRef = useRef(null);
+  const undoStack = useRef([]);
+  const redoStack = useRef([]);
+  const [, setVersion] = useState(0); // force re-render for buttons
 
   // Charger une valeur initiale (dataURL) si fournie
   useEffect(() => {
-    if (!sigRef.current || !initialValue) return;
+    if (!sigRef.current) return;
     try {
-      sigRef.current.fromDataURL(initialValue);
+      if (initialValue) {
+        sigRef.current.fromDataURL(initialValue);
+      } else {
+        sigRef.current.clear();
+      }
+      undoStack.current = [sigRef.current.toData()];
+      redoStack.current = [];
+      setVersion(v => v + 1);
     } catch (error) {
       logService.error('Erreur lors du chargement de la signature :', error);
     }
@@ -22,12 +32,65 @@ const SignaturePadComponent = ({ onEnd, onChange, initialValue, canvasProps }) =
     };
   }, []);
 
+  // Ajuster le canvas pour les écrans haute densité
+  useEffect(() => {
+    const resizeCanvas = () => {
+      const canvas = sigRef.current?.getCanvas();
+      if (!canvas) return;
+      const ratio = Math.max(window.devicePixelRatio || 1, 1);
+      const { offsetWidth, offsetHeight } = canvas;
+      canvas.width = offsetWidth * ratio;
+      canvas.height = offsetHeight * ratio;
+      canvas.getContext('2d').scale(ratio, ratio);
+      const data = undoStack.current[undoStack.current.length - 1];
+      if (data) sigRef.current.fromData(data);
+    };
+    resizeCanvas();
+    window.addEventListener('resize', resizeCanvas);
+    return () => window.removeEventListener('resize', resizeCanvas);
+  }, []);
+
   // Callback de fin de signature — déclenche les updates ici seulement
   const handleEnd = useCallback(() => {
     if (!sigRef.current) return;
     const dataUrl = sigRef.current.toDataURL('image/png');
     onEnd?.(dataUrl);
     onChange?.(dataUrl);
+    undoStack.current.push(sigRef.current.toData());
+    redoStack.current = [];
+    setVersion(v => v + 1);
+  }, [onEnd, onChange]);
+
+  const handleUndo = useCallback(() => {
+    if (undoStack.current.length <= 1) return;
+    redoStack.current.push(undoStack.current.pop());
+    const data = undoStack.current[undoStack.current.length - 1] || [];
+    sigRef.current.fromData(data);
+    const dataUrl = sigRef.current.isEmpty() ? '' : sigRef.current.toDataURL('image/png');
+    onEnd?.(dataUrl);
+    onChange?.(dataUrl);
+    setVersion(v => v + 1);
+  }, [onEnd, onChange]);
+
+  const handleRedo = useCallback(() => {
+    if (redoStack.current.length === 0) return;
+    const data = redoStack.current.pop();
+    undoStack.current.push(data);
+    sigRef.current.fromData(data);
+    const dataUrl = sigRef.current.isEmpty() ? '' : sigRef.current.toDataURL('image/png');
+    onEnd?.(dataUrl);
+    onChange?.(dataUrl);
+    setVersion(v => v + 1);
+  }, [onEnd, onChange]);
+
+  const handleClear = useCallback(() => {
+    if (!sigRef.current) return;
+    sigRef.current.clear();
+    undoStack.current.push([]);
+    redoStack.current = [];
+    onEnd?.('');
+    onChange?.('');
+    setVersion(v => v + 1);
   }, [onEnd, onChange]);
 
   return (
@@ -52,7 +115,21 @@ const SignaturePadComponent = ({ onEnd, onChange, initialValue, canvasProps }) =
       />
       <div className="mt-2 flex items-center gap-2">
         <button
-          onClick={() => sigRef.current?.clear()}
+          onClick={handleUndo}
+          disabled={undoStack.current.length <= 1}
+          className="bg-gray-200 text-gray-800 px-3 py-1 rounded hover:bg-gray-300 text-sm disabled:opacity-50"
+        >
+          Annuler
+        </button>
+        <button
+          onClick={handleRedo}
+          disabled={redoStack.current.length === 0}
+          className="bg-gray-200 text-gray-800 px-3 py-1 rounded hover:bg-gray-300 text-sm disabled:opacity-50"
+        >
+          Rétablir
+        </button>
+        <button
+          onClick={handleClear}
           className="bg-red-500 text-white px-4 py-1 rounded hover:bg-red-600 text-sm"
         >
           Effacer


### PR DESCRIPTION
## Summary
- add undo/redo capabilities using toData/fromData stacks
- scale signature canvas by devicePixelRatio for crisp output
- provide buttons for undo, redo, clear and save

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm ci` *(fails: Package pixman-1 not found, canvas build error)*


------
https://chatgpt.com/codex/tasks/task_e_68ae221300088333a53aa266ca2a42b7