### PR TITLE
feat: add password strength indicator

### DIFF
--- a/frontend/src/components/PasswordStrengthIndicator.js
+++ b/frontend/src/components/PasswordStrengthIndicator.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+const strengthLevels = [
+  { label: 'Très faible', color: 'bg-red-500' },
+  { label: 'Faible', color: 'bg-orange-500' },
+  { label: 'Moyen', color: 'bg-yellow-500' },
+  { label: 'Fort', color: 'bg-green-500' },
+];
+
+const getStrengthScore = (password) => {
+  let score = 0;
+  if (!password) return score;
+  if (password.length >= 8) score++;
+  if (/[A-Z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^A-Za-z0-9]/.test(password)) score++;
+  return Math.min(score, 4);
+};
+
+const PasswordStrengthIndicator = ({ password }) => {
+  const score = getStrengthScore(password);
+  const width = `${(score / 4) * 100}%`;
+  const level = strengthLevels[score - 1];
+
+  return (
+    <div className="mt-2">
+      <div className="h-2 w-full bg-gray-200 rounded">
+        <div
+          className={`h-full rounded ${level ? level.color : ''}`}
+          style={{ width }}
+        />
+      </div>
+      {level && (
+        <p className="mt-1 text-xs text-gray-600">Force: {level.label}</p>
+      )}
+    </div>
+  );
+};
+
+export default PasswordStrengthIndicator;

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -142,6 +142,8 @@ const LoginPage = () => {
                   type="button"
                   className="absolute inset-y-0 right-0 pr-3 flex items-center"
                   onClick={() => setShowPassword(!showPassword)}
+                  aria-pressed={showPassword}
+                  aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
                 >
                   {showPassword ? (
                     <EyeOff className="h-5 w-5 text-gray-400 hover:text-gray-600" />

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -6,6 +6,7 @@ import {
   User, Mail, Calendar, Phone, MapPin, Upload, Eye, EyeOff,
   Save, Lock, CheckCircle, XCircle, Camera, Edit3, Shield
 } from 'lucide-react';
+import PasswordStrengthIndicator from '../components/PasswordStrengthIndicator';
 import { profileSchema, passwordChangeSchema } from '../validation/schemas';
 
 const ProfilePage = () => {
@@ -561,6 +562,8 @@ useEffect(() => {
                     type="button"
                     className="absolute inset-y-0 right-0 pr-3 flex items-center"
                     onClick={() => setShowOldPassword(!showOldPassword)}
+                    aria-pressed={showOldPassword}
+                    aria-label={showOldPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
                   >
                     {showOldPassword ? (
                       <EyeOff className="h-5 w-5 text-gray-400 hover:text-gray-600" />
@@ -594,6 +597,8 @@ useEffect(() => {
                     type="button"
                     className="absolute inset-y-0 right-0 pr-3 flex items-center"
                     onClick={() => setShowNewPassword(!showNewPassword)}
+                    aria-pressed={showNewPassword}
+                    aria-label={showNewPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
                   >
                     {showNewPassword ? (
                       <EyeOff className="h-5 w-5 text-gray-400 hover:text-gray-600" />
@@ -602,6 +607,7 @@ useEffect(() => {
                     )}
                   </button>
                 </div>
+                <PasswordStrengthIndicator password={passwordData.new_password} />
                 <p className="mt-2 text-sm text-gray-500">
                   Le mot de passe doit contenir au moins 5 caractères
                 </p>

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -312,6 +312,8 @@ const handleResendEmail = async () => {
                       type="button"
                       className="absolute inset-y-0 right-0 pr-3 flex items-center"
                       onClick={() => setShowPassword(!showPassword)}
+                      aria-pressed={showPassword}
+                      aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
                     >
                       {showPassword ? (
                         <EyeOff className="h-5 w-5 text-gray-400 hover:text-gray-600" />


### PR DESCRIPTION
## Summary
- add custom password strength indicator for new password
- improve password visibility toggle accessibility with aria attributes

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0bdf23188333913df1c8754360e2