### PR TITLE
Gracefully handle missing user during cookie auth

### DIFF
--- a/backend/signature/authentication.py
+++ b/backend/signature/authentication.py
@@ -1,6 +1,9 @@
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken
 from rest_framework.exceptions import AuthenticationFailed
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
 
 class CookieJWTAuthentication(JWTAuthentication):
     """JWT authentication that also reads tokens from HttpOnly cookies."""
@@ -18,4 +21,9 @@ class CookieJWTAuthentication(JWTAuthentication):
         except (InvalidToken, AuthenticationFailed):
             request._delete_auth_cookies = True
             return None
-        return self.get_user(validated_token), validated_token
+        try:
+            user = self.get_user(validated_token)
+        except (AuthenticationFailed, User.DoesNotExist):
+            request._delete_auth_cookies = True
+            return None
+        return user, validated_token

--- a/backend/signature/tests/test_authentication.py
+++ b/backend/signature/tests/test_authentication.py
@@ -15,3 +15,21 @@ class CookieAuthenticationTests(APITestCase):
         self.assertEqual(response.cookies['refresh_token'].value, '')
         self.assertNotIn('access_token', self.client.cookies)
         self.assertNotIn('refresh_token', self.client.cookies)
+
+    def test_register_with_invalid_cookie_returns_201(self):
+        url = reverse('register')
+        self.client.cookies['access_token'] = 'bad'
+        self.client.cookies['refresh_token'] = 'bad'
+        data = {
+            'username': 'newuser',
+            'email': 'newuser@example.com',
+            'password': 'secret123'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 201)
+        self.assertIn('access_token', response.cookies)
+        self.assertIn('refresh_token', response.cookies)
+        self.assertEqual(response.cookies['access_token'].value, '')
+        self.assertEqual(response.cookies['refresh_token'].value, '')
+        self.assertNotIn('access_token', self.client.cookies)
+        self.assertNotIn('refresh_token', self.client.cookies)


### PR DESCRIPTION
## Summary
- Clear auth cookies when user lookup fails during cookie-based JWT auth
- Add regression test verifying register succeeds (201) even with invalid cookies

## Testing
- `python manage.py test` *(fails: Set the POSTGRES_DB environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b46f804d70833382428e726f0a93df