### PR TITLE
Place ClearAuthCookiesMiddleware immediately after AuthenticationMiddleware

### DIFF
--- a/backend/esign/settings.py
+++ b/backend/esign/settings.py
@@ -59,9 +59,9 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "signature.middleware.ClearAuthCookiesMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "signature.middleware.ClearAuthCookiesMiddleware",
 ]
 
 ROOT_URLCONF = "esign.urls"


### PR DESCRIPTION
## Summary
- insert ClearAuthCookiesMiddleware right after AuthenticationMiddleware in Django settings

## Testing
- `cd backend && python manage.py test` *(fails: django.core.exceptions.ImproperlyConfigured: Set the DJANGO_SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b46f7fba808333803f806b5eba27d1