### PR TITLE
fix: scale PDF widths to container

### DIFF
--- a/frontend/src/pages/DocumentDetail.js
+++ b/frontend/src/pages/DocumentDetail.js
@@ -116,6 +116,10 @@ const DocumentDetail = () => {
     };
   }, []);
 
+  const isMobileView = window.innerWidth < 768;
+  const padding = isMobileView ? 16 : 48;
+  const pageMaxWidth = Math.max(0, Math.min(viewerWidth - padding, 900));
+
   // Libération URL blob
   useEffect(() => {
     return () => {
@@ -501,7 +505,7 @@ const DocumentDetail = () => {
                     <div key={i} className="relative mb-4 lg:mb-6 shadow-lg rounded-lg overflow-hidden">
                       <Page
                         pageNumber={i + 1}
-                        width={Math.max(viewerWidth, 300)}
+                        width={pageMaxWidth}
                         renderTextLayer={false}
                         className="mx-auto"
                       />

--- a/frontend/src/pages/DocumentSign.js
+++ b/frontend/src/pages/DocumentSign.js
@@ -337,7 +337,7 @@ export default function DocumentSign() {
         {numPages > 0 && Array.from({ length: numPages }, (_, i) => {
           const n = i + 1;
           const padding = isMobile ? 24 : 48; // SelfSign-like
-          const pageMaxWidth = Math.min(Math.max((viewerWidth || 600) - padding, 320), 900);
+          const pageMaxWidth = Math.max(0, Math.min(viewerWidth - padding, 900));
           const s = pageMaxWidth / (pageDims[n]?.width || 1);
           const fields = currentFields.filter((f) => f.page === n);
 

--- a/frontend/src/pages/DocumentWorkflow.js
+++ b/frontend/src/pages/DocumentWorkflow.js
@@ -877,8 +877,7 @@ export default function DocumentWorkflow() {
       const padding = isMobileView ? 16 : 48;
       const container = node.clientWidth || 0;
       const maxWidth = isMobileView ? 600 : 900;
-      const minWidth = isMobileView ? 280 : 320;
-      const nextWidth = Math.min(Math.max(container - padding, minWidth), maxWidth);
+      const nextWidth = Math.max(0, Math.min(container - padding, maxWidth));
       if (Math.abs(nextWidth - lastWidth) >= MIN_DELTA) {
         lastWidth = nextWidth;
         setPdfWidth(nextWidth);


### PR DESCRIPTION
## Summary
- ensure PDF pages cap to container width before rendering
- simplify width calculations across signing, detail, and workflow pages

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `CI=true npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb965ddc883338d8da79f7c9d3222