### PR TITLE
refactor: add reusable signature modal

### DIFF
--- a/frontend/src/components/SignatureModal.js
+++ b/frontend/src/components/SignatureModal.js
@@ -1,0 +1,157 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Modal from 'react-modal';
+import { toast } from 'react-toastify';
+import SignaturePadComponent from './SignaturePadComponent';
+import useFocusTrap from '../hooks/useFocusTrap';
+import { fileToPngDataURL, savedSignatureImageUrl, fetchSavedSignatureAsDataURL } from '../utils/signatureUtils';
+
+export default function SignatureModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  savedSignatures = [],
+  initialDataUrl = '',
+  initialSavedId = null,
+  style = {}
+}) {
+  const [mode, setMode] = useState('draw');
+  const [tempDataUrl, setTempDataUrl] = useState('');
+  const [savedSelectedId, setSavedSelectedId] = useState(null);
+  const modalRef = useRef(null);
+  useFocusTrap(modalRef, isOpen);
+  const triggerRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      triggerRef.current = document.activeElement;
+      setMode(initialSavedId ? 'saved' : 'draw');
+      setTempDataUrl(initialDataUrl || '');
+      setSavedSelectedId(initialSavedId || null);
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+  }, [isOpen, initialDataUrl, initialSavedId]);
+
+  useEffect(() => {
+    if (!isOpen && triggerRef.current) {
+      triggerRef.current.focus();
+    }
+  }, [isOpen]);
+
+  const handleUpload = async (ev) => {
+    const f = ev.target.files?.[0];
+    if (!f) return;
+    if (!f.type.startsWith('image/')) return toast.error('Veuillez importer une image (PNG/JPG/SVG)');
+    try {
+      const dataUrl = await fileToPngDataURL(f);
+      setTempDataUrl(dataUrl);
+    } catch {
+      toast.error("Impossible de lire l'image");
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!tempDataUrl) return toast.error('Veuillez fournir une signature');
+    onConfirm(tempDataUrl, savedSelectedId);
+  };
+
+  const defaultStyle = {
+    overlay: { zIndex: 10000, backgroundColor: 'rgba(0,0,0,0.5)' },
+    content: { zIndex: 10001, inset: '10% 20%', borderRadius: 12, padding: 16 }
+  };
+  const mergedStyle = {
+    overlay: { ...defaultStyle.overlay, ...(style.overlay || {}) },
+    content: { ...defaultStyle.content, ...(style.content || {}) }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      ariaHideApp={false}
+      contentLabel="Signer"
+      shouldCloseOnOverlayClick
+      shouldCloseOnEsc
+      style={mergedStyle}
+      contentRef={(node) => (modalRef.current = node)}
+    >
+      <h2 className="text-lg font-semibold mb-3">Ajouter une signature</h2>
+
+      <div className="flex items-center gap-4 mb-3">
+        <label className="flex items-center gap-2">
+          <input type="radio" name="mode" checked={mode==='draw'} onChange={() => setMode('draw')} />
+          <span>Dessiner</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="radio" name="mode" checked={mode==='upload'} onChange={() => setMode('upload')} />
+          <span>Importer</span>
+        </label>
+        {!!savedSignatures.length && (
+          <label className="flex items-center gap-2">
+            <input type="radio" name="mode" checked={mode==='saved'} onChange={() => setMode('saved')} />
+            <span>Mes signatures</span>
+          </label>
+        )}
+      </div>
+
+      {mode === 'draw' && (
+        <SignaturePadComponent
+          mode="draw"
+          onChange={(d) => setTempDataUrl(d)}
+          onEnd={(d) => setTempDataUrl(d)}
+          initialValue={tempDataUrl}
+        />
+      )}
+
+      {mode === 'upload' && (
+        <div className="space-y-3">
+          <input type="file" accept="image/*" onChange={handleUpload} className="block w-full text-sm" />
+          {tempDataUrl ? (
+            <div className="border rounded p-2 inline-block"><img src={tempDataUrl} alt="Aperçu signature" style={{ maxWidth: 320, maxHeight: 160 }} /></div>
+          ) : (
+            <p className="text-sm text-gray-600">Choisissez une image (PNG/JPG/SVG).</p>
+          )}
+          {tempDataUrl && (
+            <button type="button" onClick={() => setTempDataUrl('')} className="px-3 py-1 rounded bg-gray-200 text-gray-800">Effacer</button>
+          )}
+        </div>
+      )}
+
+      {mode === 'saved' && (
+        <div className="grid grid-cols-2 gap-2 max-h-64 overflow-auto">
+          {savedSignatures.map(sig => {
+            const previewSrc = sig.data_url || savedSignatureImageUrl(sig.id);
+            return (
+              <button
+                type="button"
+                key={sig.id}
+                className={`relative border p-1 rounded flex items-center justify-center h-24 ${savedSelectedId===sig.id ? 'ring-2 ring-blue-600 border-blue-600 bg-blue-50' : 'hover:bg-gray-50'}`}
+                onClick={async () => {
+                  try {
+                    const dataUrl = await fetchSavedSignatureAsDataURL(sig);
+                    setTempDataUrl(dataUrl);
+                    setSavedSelectedId(sig.id);
+                  } catch {
+                    toast.error('Impossible de charger la signature');
+                  }
+                }}
+              >
+                <img src={previewSrc} alt="saved" className="max-h-20 w-full object-contain" />
+                {savedSelectedId===sig.id && <span className="absolute top-1 right-1 text-[10px] px-1 rounded bg-blue-600 text-white">Choisie</span>}
+              </button>
+            );
+          })}
+          {!savedSignatures.length && <p className="text-sm">Aucune signature enregistrée.</p>}
+        </div>
+      )}
+
+      <div className="mt-4 flex justify-end gap-2">
+        <button onClick={onClose} className="px-4 py-2 rounded bg-gray-200">Annuler</button>
+        <button onClick={handleConfirm} className="px-4 py-2 rounded bg-green-600 text-white">Valider</button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/SelfSignWizard.js
+++ b/frontend/src/pages/SelfSignWizard.js
@@ -4,80 +4,13 @@ import { toast } from 'react-toastify';
 import { FiUpload, FiX, FiEdit3, FiMenu, FiTrash2 } from 'react-icons/fi';
 import signatureService from '../services/signatureService';
 import { api } from '../services/apiUtils';
-import Modal from 'react-modal';
-import SignaturePadComponent from '../components/SignaturePadComponent';
+import SignatureModal from '../components/SignatureModal';
+import { fileToPngDataURL, blobToPngDataURL, savedSignatureImageUrl, fetchSavedSignatureAsDataURL } from '../utils/signatureUtils';
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 /* -------------------------- helpers compacts -------------------------- */
 
-// URL absolue de l’image d’une signature enregistrée
-const savedSignatureImageUrl = (id) =>
-  `${(api?.defaults?.baseURL || '').replace(/\/$/, '')}/api/signature/saved-signatures/${id}/image/`;
-
-// Rasterise n’importe quel blob en data:image/png;base64,...
-const blobToPngDataURL = async (blob) => {
-  try {
-    const bmp = await createImageBitmap(blob);
-    const c = document.createElement('canvas');
-    c.width = bmp.width; c.height = bmp.height;
-    c.getContext('2d').drawImage(bmp, 0, 0);
-    return c.toDataURL('image/png');
-  } catch {
-    const url = URL.createObjectURL(blob);
-    const dataUrl = await new Promise((resolve, reject) => {
-      const img = new Image();
-      img.onload = () => {
-        const c = document.createElement('canvas');
-        c.width = img.naturalWidth; c.height = img.naturalHeight;
-        c.getContext('2d').drawImage(img, 0, 0);
-        resolve(c.toDataURL('image/png'));
-        URL.revokeObjectURL(url);
-      };
-      img.onerror = reject;
-      img.src = url;
-    });
-    return dataUrl;
-  }
-};
-
-// Convertit un File d'image en data:image/png;base64
-const fileToPngDataURL = async (file) => {
-  try {
-    const bmp = await createImageBitmap(file);
-    const c = document.createElement('canvas');
-    c.width = bmp.width; c.height = bmp.height;
-    c.getContext('2d').drawImage(bmp, 0, 0);
-    return c.toDataURL('image/png');
-  } catch {
-    // fallback via FileReader -> Image
-    const dataUrl = await new Promise((resolve, reject) => {
-      const fr = new FileReader();
-      fr.onload = () => {
-        const img = new Image();
-        img.onload = () => {
-          const c = document.createElement('canvas');
-          c.width = img.naturalWidth; c.height = img.naturalHeight;
-          c.getContext('2d').drawImage(img, 0, 0);
-          resolve(c.toDataURL('image/png'));
-        };
-        img.onerror = reject;
-        img.src = fr.result;
-      };
-      fr.onerror = reject;
-      fr.readAsDataURL(file);
-    });
-    return dataUrl;
-  }
-};
-
-// Charge l’image d’une signature enregistrée → dataURL PNG
-const fetchSavedSignatureAsDataURL = async (sig) => {
-  if (sig?.data_url) return sig.data_url;
-  const res = await fetch(savedSignatureImageUrl(sig.id), { credentials: 'include' });
-  if (!res.ok) throw new Error('HTTP ' + res.status);
-  return blobToPngDataURL(await res.blob());
-};
 
 /* ----------------------------- Draggable ------------------------------ */
 
@@ -333,123 +266,6 @@ const DraggableSignature = React.memo(function DraggableSignature({
   );
 });
 
-/* ------------------------------ Modal UI ------------------------------ */
-
-function SignatureModal({ isOpen, onClose, onConfirm, savedSignatures }) {
-  const [mode, setMode] = useState('draw'); // 'draw' | 'upload' | 'saved'
-  const [tempDataUrl, setTempDataUrl] = useState('');
-  const [savedSelectedId, setSavedSelectedId] = useState(null);
-
-  // Reset à l’ouverture
-  useEffect(() => {
-    if (isOpen) {
-      setMode('draw');
-      setTempDataUrl('');
-      setSavedSelectedId(null);
-    }
-  }, [isOpen]);
-
-  const handleUpload = async (ev) => {
-    const f = ev.target.files?.[0];
-    if (!f) return;
-    if (!f.type.startsWith('image/')) return toast.error('Veuillez importer une image');
-    try {
-      const dataUrl = await fileToPngDataURL(f);
-      setTempDataUrl(dataUrl);
-    } catch {
-      toast.error("Impossible de lire l'image");
-    }
-  };
-
-  return (
-    <Modal
-      isOpen={isOpen}
-      onRequestClose={onClose}
-      ariaHideApp={false}
-      contentLabel="Signer"
-      style={{
-        overlay: { zIndex: 10000, backgroundColor: 'rgba(0,0,0,0.5)' },
-        content: { zIndex: 10001, inset: '10% 20%', borderRadius: 12, padding: 16 }
-      }}
-    >
-      <h2 className="text-lg font-semibold mb-3">Ajouter une signature</h2>
-
-      <div className="flex items-center gap-4 mb-3">
-        <label className="flex items-center gap-2">
-          <input type="radio" name="mode" checked={mode==='draw'} onChange={()=>setMode('draw')} />
-          <span>Dessiner</span>
-        </label>
-        <label className="flex items-center gap-2">
-          <input type="radio" name="mode" checked={mode==='upload'} onChange={()=>setMode('upload')} />
-          <span>Importer</span>
-        </label>
-        {!!savedSignatures.length && (
-          <label className="flex items-center gap-2">
-            <input type="radio" name="mode" checked={mode==='saved'} onChange={()=>setMode('saved')} />
-            <span>Mes signatures</span>
-          </label>
-        )}
-      </div>
-
-      {mode === 'draw' && (
-        <SignaturePadComponent
-          mode="draw"
-          onChange={(dataUrl)=> setTempDataUrl(dataUrl)}
-          onEnd={(dataUrl)=> setTempDataUrl(dataUrl)}
-          initialValue={tempDataUrl}
-        />
-      )}
-
-      {mode === 'upload' && (
-        <div className="space-y-3">
-          <input type="file" accept="image/*" onChange={handleUpload} className="block w-full text-sm" />
-          {tempDataUrl
-            ? (
-              <div className="border rounded p-2 inline-block">
-                <img src={tempDataUrl} alt="Aperçu signature" style={{ maxWidth: 320, maxHeight: 160 }} />
-              </div>
-            )
-            : <p className="text-sm text-gray-600">Choisissez une image (PNG/JPG/SVG).</p>
-          }
-          {tempDataUrl && (
-            <button type="button" onClick={()=> setTempDataUrl('')} className="px-3 py-1 rounded bg-gray-200 text-gray-800">Effacer</button>
-          )}
-        </div>
-      )}
-
-      {mode === 'saved' && (
-        <div className="grid grid-cols-2 gap-2 max-h-64 overflow-auto">
-          {savedSignatures.map(sig => {
-            const previewSrc = sig.data_url || savedSignatureImageUrl(sig.id);
-            return (
-              <button
-                type="button"
-                key={sig.id}
-                className={`relative border p-1 rounded flex items-center justify-center h-24 ${savedSelectedId===sig.id ? 'ring-2 ring-blue-600 border-blue-600 bg-blue-50' : 'hover:bg-gray-50'}`}
-                onClick={async ()=>{
-                  try {
-                    const dataUrl = await fetchSavedSignatureAsDataURL(sig);
-                    setTempDataUrl(dataUrl);
-                    setSavedSelectedId(sig.id);
-                  } catch { toast.error('Impossible de charger la signature'); }
-                }}
-              >
-                <img src={previewSrc} alt="saved" className="max-h-20 w-full object-contain" />
-                {savedSelectedId===sig.id && <span className="absolute top-1 right-1 text-[10px] px-1 rounded bg-blue-600 text-white">Choisie</span>}
-              </button>
-            );
-          })}
-          {!savedSignatures.length && <p className="text-sm">Aucune signature enregistrée.</p>}
-        </div>
-      )}
-
-      <div className="mt-4 flex justify-end gap-2">
-        <button onClick={onClose} className="px-4 py-2 rounded bg-gray-200">Annuler</button>
-        <button onClick={()=> { if(!tempDataUrl) return toast.error('Veuillez fournir une signature'); onConfirm(tempDataUrl); }} className="px-4 py-2 rounded bg-green-600 text-white">Valider</button>
-      </div>
-    </Modal>
-  );
-}
 
 /* ------------------------------ composant ------------------------------ */
 
@@ -800,9 +616,10 @@ export default function SelfSignWizard() {
       {/* MODAL signature */}
       <SignatureModal
         isOpen={modalOpen}
-        onClose={()=> setModalOpen(false)}
+        onClose={() => setModalOpen(false)}
         onConfirm={handleModalConfirm}
         savedSignatures={savedSignatures}
+        initialDataUrl={sigDataUrl}
       />
     </div>
   );

--- a/frontend/src/utils/signatureUtils.js
+++ b/frontend/src/utils/signatureUtils.js
@@ -1,0 +1,74 @@
+import { api } from '../services/apiUtils';
+
+export const savedSignatureImageUrl = (id) => `${(api?.defaults?.baseURL || '').replace(/\/$/, '')}/api/signature/saved-signatures/${id}/image/`;
+
+export const blobToPngDataURL = async (blob) => {
+  try {
+    const bmp = await createImageBitmap(blob);
+    const c = document.createElement('canvas');
+    c.width = bmp.width;
+    c.height = bmp.height;
+    c.getContext('2d').drawImage(bmp, 0, 0);
+    return c.toDataURL('image/png');
+  } catch {
+    const url = URL.createObjectURL(blob);
+    const dataUrl = await new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => {
+        const c = document.createElement('canvas');
+        c.width = img.naturalWidth;
+        c.height = img.naturalHeight;
+        c.getContext('2d').drawImage(img, 0, 0);
+        resolve(c.toDataURL('image/png'));
+        URL.revokeObjectURL(url);
+      };
+      img.onerror = reject;
+      img.src = url;
+    });
+    return dataUrl;
+  }
+};
+
+export const fileToPngDataURL = async (file) => {
+  try {
+    const bmp = await createImageBitmap(file);
+    const c = document.createElement('canvas');
+    c.width = bmp.width;
+    c.height = bmp.height;
+    c.getContext('2d').drawImage(bmp, 0, 0);
+    return c.toDataURL('image/png');
+  } catch {
+    const dataUrl = await new Promise((resolve, reject) => {
+      const fr = new FileReader();
+      fr.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          const c = document.createElement('canvas');
+          c.width = img.naturalWidth;
+          c.height = img.naturalHeight;
+          c.getContext('2d').drawImage(img, 0, 0);
+          resolve(c.toDataURL('image/png'));
+        };
+        img.onerror = reject;
+        img.src = fr.result;
+      };
+      fr.onerror = reject;
+      fr.readAsDataURL(file);
+    });
+    return dataUrl;
+  }
+};
+
+export const fetchSavedSignatureAsDataURL = async (sig) => {
+  if (sig?.data_url) return sig.data_url;
+  const res = await fetch(savedSignatureImageUrl(sig.id), { credentials: 'include' });
+  if (!res.ok) throw new Error('HTTP ' + res.status);
+  return blobToPngDataURL(await res.blob());
+};
+
+export default {
+  fileToPngDataURL,
+  blobToPngDataURL,
+  savedSignatureImageUrl,
+  fetchSavedSignatureAsDataURL,
+};


### PR DESCRIPTION
## Summary
- centralize signature upload/draw/saved logic into new SignatureModal component
- extract shared signature utility helpers for data URL conversion
- update signing pages to use the new modal

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bed492efac8333afbc84c649881825