### PR TITLE
Store signature positions as relative percentages

### DIFF
--- a/backend/signature/serializers.py
+++ b/backend/signature/serializers.py
@@ -187,13 +187,14 @@ class SigningFieldSerializer(serializers.ModelSerializer):
         required_keys = {'x', 'y', 'width', 'height'}
         if not isinstance(value, dict) or not required_keys.issubset(value.keys()):
             raise serializers.ValidationError('position doit contenir x, y, width, height')
-        # bornes simples (>=0)
+        # bornes : valeurs relatives entre 0 et 1
         for k in ['x', 'y', 'width', 'height']:
             try:
-                if float(value[k]) < 0:
-                    raise serializers.ValidationError(f'position.{k} doit être >= 0')
+                v = float(value[k])
             except Exception:
                 raise serializers.ValidationError(f'position.{k} invalide')
+            if not 0 <= v <= 1:
+                raise serializers.ValidationError(f'position.{k} doit être entre 0 et 1')
         return value
 
     def validate_page(self, value):

--- a/backend/signature/tasks.py
+++ b/backend/signature/tasks.py
@@ -126,7 +126,7 @@ def send_signed_pdf_to_all_signers(envelope_id: int):
 def _paste_signature_on_pdf(pdf_bytes: bytes, sig_img_bytes: bytes, placements: list) -> bytes:
     """
     Appose l'image de signature aux positions indiquées (page,x,y,width,height)
-    - x,y,width,height : unités PDF (points) mesurées depuis le HAUT-GAUCHE de la CropBox dans le front.
+    - x,y,width,height : valeurs relatives (0-1) mesurées depuis le HAUT-GAUCHE de la CropBox dans le front.
     - Conversion ici vers repère PDF (bas-gauche) + offset CropBox.
     Retourne un PDF bytes (non signé crypto).
     """
@@ -175,11 +175,11 @@ def _paste_signature_on_pdf(pdf_bytes: bytes, sig_img_bytes: bytes, placements: 
         c = canvas.Canvas(packet, pagesize=(media_w, media_h))
 
         for pl in by_page[page_num]:
-            # UI: x,y depuis TOP-LEFT de CropBox  → PDF: BOTTOM-LEFT MediaBox
-            x_ui = pl["x"]
-            y_ui = pl["y"]
-            w = pl["width"]
-            h = pl["height"]
+            # UI: x,y,width,height relatifs [0,1]
+            x_ui = pl["x"] * crop_w
+            y_ui = pl["y"] * crop_h
+            w = pl["width"] * crop_w
+            h = pl["height"] * crop_h
 
             # inverser Y dans la CropBox
             y_from_bottom_in_crop = crop_h - y_ui - h

--- a/backend/signature/views/envelope.py
+++ b/backend/signature/views/envelope.py
@@ -660,13 +660,26 @@ class EnvelopeViewSet(viewsets.ModelViewSet):
         # 3) TRAITEMENT CHAMP PAR CHAMP : overlay + signature immédiatement
         for i, fmeta in enumerate(my_fields_meta):
             pos = fmeta.get('position') or {}
-            try:
-                x = float(pos.get('x', 0)); y_top = float(pos.get('y', 0))
-                w = float(pos.get('width', 0)); h = float(pos.get('height', 0))
-            except Exception:
-                x, y_top, w, h = 0, 0, 180, 60
             page_num = int(fmeta.get('page') or 1)
             page_ix = max(0, page_num - 1)
+
+            reader_dim = PdfReader(io.BytesIO(base_bytes))
+            page = reader_dim.pages[page_ix]
+            page_w = float(page.mediabox.width)
+            page_h = float(page.mediabox.height)
+
+            try:
+                x_rel = float(pos.get('x', 0)); y_rel = float(pos.get('y', 0))
+                w_rel = float(pos.get('width', 0)); h_rel = float(pos.get('height', 0))
+            except Exception:
+                x_rel = y_rel = 0
+                w_rel = 180 / page_w
+                h_rel = 60 / page_h
+
+            x = x_rel * page_w
+            y_top = y_rel * page_h
+            w = w_rel * page_w
+            h = h_rel * page_h
     
             # Extraire l'image de signature POUR CE CHAMP
             field_id = str(fmeta.get('id') or fmeta.get('field_id') or '')

--- a/frontend/src/pages/DocumentSign.js
+++ b/frontend/src/pages/DocumentSign.js
@@ -337,10 +337,10 @@ export default function DocumentSign() {
                       title={field.editable ? 'Cliquer pour signer' : 'Champ non éditable'}
                       className={`absolute flex items-center justify-center text-[11px] font-semibold border-2 rounded ${field.signed ? 'border-green-500 bg-green-100' : 'border-red-500 bg-red-100 hover:bg-red-200'} ${field.editable ? 'focus:outline-none focus:ring-2 focus:ring-blue-500' : ''}`}
                       style={{
-                        top: field.position.y * s,
-                        left: field.position.x * s,
-                        width: field.position.width * s,
-                        height: field.position.height * s,
+                        top: field.position.y * (pageDims[n]?.height || 0) * s,
+                        left: field.position.x * (pageDims[n]?.width || 0) * s,
+                        width: field.position.width * (pageDims[n]?.width || 0) * s,
+                        height: field.position.height * (pageDims[n]?.height || 0) * s,
                       }}
                     >
                       {field.signed ? (

--- a/frontend/src/pages/DocumentWorkflow.js
+++ b/frontend/src/pages/DocumentWorkflow.js
@@ -25,7 +25,8 @@ function debounce(func, wait) {
    ========================= */
 const DraggableSignature = React.memo(function DraggableSignature({
   field,
-  factor,
+  pageWidth,
+  pageHeight,
   isMobileView,
   onUpdate,
   onDelete
@@ -38,10 +39,10 @@ const DraggableSignature = React.memo(function DraggableSignature({
 
   const style = useMemo(() => ({
     position: 'absolute',
-    left: field.position.x * factor,
-    top: field.position.y * factor,
-    width: field.position.width * factor,
-    height: field.position.height * factor,
+    left: field.position.x * pageWidth,
+    top: field.position.y * pageHeight,
+    width: field.position.width * pageWidth,
+    height: field.position.height * pageHeight,
     borderRadius: 8,
     boxShadow: '0 0 0 1px rgba(0,0,0,.20), 0 2px 6px rgba(0,0,0,.08)',
     background: '#fff',
@@ -52,7 +53,7 @@ const DraggableSignature = React.memo(function DraggableSignature({
     cursor: isDragging ? 'grabbing' : 'grab',
     border: '2px solid transparent',
     userSelect: 'none',
-  }), [field.position, factor, isDragging]);
+  }), [field.position, pageWidth, pageHeight, isDragging]);
 
   const handleMouseDown = useCallback((e) => {
     if (e.target.classList.contains('resize-handle')) return;
@@ -113,8 +114,8 @@ const DraggableSignature = React.memo(function DraggableSignature({
 
     const handleMouseMove = (e) => {
       if (isDragging) {
-        const deltaX = (e.clientX - dragStart.x) / factor;
-        const deltaY = (e.clientY - dragStart.y) / factor;
+        const deltaX = (e.clientX - dragStart.x) / pageWidth;
+        const deltaY = (e.clientY - dragStart.y) / pageHeight;
         const newPosition = {
           ...field.position,
           x: Math.max(0, dragStart.fieldX + deltaX),
@@ -122,12 +123,12 @@ const DraggableSignature = React.memo(function DraggableSignature({
         };
         onUpdate(field, { position: newPosition });
       } else if (isResizing) {
-        const deltaX = (e.clientX - resizeStart.x) / factor;
-        const deltaY = (e.clientY - resizeStart.y) / factor;
+        const deltaX = (e.clientX - resizeStart.x) / pageWidth;
+        const deltaY = (e.clientY - resizeStart.y) / pageHeight;
         const newPosition = {
           ...field.position,
-          width: Math.max(50 / factor, resizeStart.width + deltaX),
-          height: Math.max(20 / factor, resizeStart.height + deltaY)
+          width: Math.max(50 / pageWidth, resizeStart.width + deltaX),
+          height: Math.max(20 / pageHeight, resizeStart.height + deltaY)
         };
         onUpdate(field, { position: newPosition });
       }
@@ -143,8 +144,8 @@ const DraggableSignature = React.memo(function DraggableSignature({
       if (!touch) return;
       e.preventDefault();
       if (isDragging) {
-        const deltaX = (touch.clientX - dragStart.x) / factor;
-        const deltaY = (touch.clientY - dragStart.y) / factor;
+        const deltaX = (touch.clientX - dragStart.x) / pageWidth;
+        const deltaY = (touch.clientY - dragStart.y) / pageHeight;
         const newPosition = {
           ...field.position,
           x: Math.max(0, dragStart.fieldX + deltaX),
@@ -152,12 +153,12 @@ const DraggableSignature = React.memo(function DraggableSignature({
         };
         onUpdate(field, { position: newPosition });
       } else if (isResizing) {
-        const deltaX = (touch.clientX - resizeStart.x) / factor;
-        const deltaY = (touch.clientY - resizeStart.y) / factor;
+        const deltaX = (touch.clientX - resizeStart.x) / pageWidth;
+        const deltaY = (touch.clientY - resizeStart.y) / pageHeight;
         const newPosition = {
           ...field.position,
-          width: Math.max(50 / factor, resizeStart.width + deltaX),
-          height: Math.max(20 / factor, resizeStart.height + deltaY),
+          width: Math.max(50 / pageWidth, resizeStart.width + deltaX),
+          height: Math.max(20 / pageHeight, resizeStart.height + deltaY),
         };
         onUpdate(field, { position: newPosition });
       }
@@ -179,7 +180,7 @@ const DraggableSignature = React.memo(function DraggableSignature({
        document.removeEventListener('touchmove', handleTouchMove);
        document.removeEventListener('touchend', handleTouchEnd);
     };
-  }, [isDragging, isResizing, dragStart, resizeStart, factor, field, onUpdate]);
+  }, [isDragging, isResizing, dragStart, resizeStart, pageWidth, pageHeight, field, onUpdate]);
 
   return (
     <div
@@ -324,12 +325,14 @@ const PDFViewer = React.memo(function PDFViewer({
                             width: 600,
                             height: 800,
                           };
-                          const factor = pdfWidth / vp.width;
+                          const pageWidthPx = pdfWidth;
+                          const pageHeightPx = (vp.height / vp.width) * pdfWidth;
                           return (
                             <DraggableSignature
                               key={`${field.recipient_id}-${field.document_id}-${field.page}-${field.field_type}`}
                               field={field}
-                              factor={factor}
+                              pageWidth={pageWidthPx}
+                              pageHeight={pageHeightPx}
                               isMobileView={isMobileView}
                               onUpdate={onUpdateField}
                               onDelete={onDeleteField}
@@ -1006,12 +1009,12 @@ export default function DocumentWorkflow() {
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
     const vp = pageDimensions[selectedDocId]?.[pageNumber] || { width: 600, height: 800 };
-    const factor = pdfWidth / vp.width;
+    const pdfHeight = (vp.height / vp.width) * pdfWidth;
     const normalized = {
-      x: x / factor,
-      y: y / factor,
-      width: 150 / factor,
-      height: 50 / factor,
+      x: x / pdfWidth,
+      y: y / pdfHeight,
+      width: 150 / pdfWidth,
+      height: 50 / pdfHeight,
     };
     setFields((prev) =>
       prev.filter(


### PR DESCRIPTION
## Summary
- store signature field coordinates relative to page size on placement, drag and resize
- render signature fields by multiplying relative coordinates by current page dimensions
- convert relative coordinates to PDF points on the server before signing

## Testing
- `npm test --silent` *(fails: react-scripts: not found)*
- `DJANGO_SETTINGS_MODULE=esign.settings pytest` *(fails: Set the DJANGO_SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c09921a8dc8333b343464b4a780831