### PR TITLE
feat: add dropzone and file preview modal

### DIFF
--- a/frontend/src/components/Dropzone.js
+++ b/frontend/src/components/Dropzone.js
@@ -1,0 +1,68 @@
+import React, { useRef, useState } from 'react';
+
+const Dropzone = ({ onFiles, accept }) => {
+  const inputRef = useRef(null);
+  const [isDragActive, setIsDragActive] = useState(false);
+
+  const handleFiles = (fileList) => {
+    const files = Array.from(fileList);
+    onFiles(files);
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragActive(false);
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      handleFiles(e.dataTransfer.files);
+    }
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+    setIsDragActive(true);
+  };
+
+  const handleDragLeave = (e) => {
+    e.preventDefault();
+    setIsDragActive(false);
+  };
+
+  const handleClick = () => {
+    inputRef.current?.click();
+  };
+
+  const handleChange = (e) => {
+    handleFiles(e.target.files);
+  };
+
+  return (
+    <div
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onClick={handleClick}
+      className={`flex flex-col items-center justify-center w-full h-32 border-2 border-dashed rounded-md cursor-pointer transition-colors ${
+        isDragActive ? 'border-blue-500 bg-blue-50' : 'border-gray-300 bg-gray-50 hover:border-gray-400'
+      }`}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        accept={accept}
+        className="hidden"
+        onChange={handleChange}
+      />
+      <p className="text-sm text-gray-600 text-center px-2">
+        Glissez-déposez vos fichiers ici ou cliquez pour sélectionner
+      </p>
+    </div>
+  );
+};
+
+export default Dropzone;
+

--- a/frontend/src/pages/DocumentUpload.js
+++ b/frontend/src/pages/DocumentUpload.js
@@ -5,15 +5,17 @@ import { toast } from 'react-toastify';
 import { FiUpload, FiFileText } from 'react-icons/fi';
 import logService from '../services/logService';
 import { documentUploadSchema } from '../validation/schemas';
+import Modal from 'react-modal';
+import Dropzone from '../components/Dropzone';
 
 const DocumentUpload = () => {
   const [files, setFiles] = useState([]);
   const [title, setTitle] = useState('');
   const [errors, setErrors] = useState({});
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const navigate = useNavigate();
 
-  const handleFileChange = async (e) => {
-    const selectedFiles = Array.from(e.target.files);
+  const handleFilesChange = async (selectedFiles) => {
     setFiles(selectedFiles);
     try {
       await documentUploadSchema.validate(
@@ -59,6 +61,7 @@ const DocumentUpload = () => {
   };
 
   return (
+    <>
     <div className="max-w-2xl mx-auto px-6 py-10">
       <div className="bg-white rounded-lg shadow-lg p-6">
         <h1 className="text-2xl font-bold text-gray-800 mb-6 flex items-center gap-2">
@@ -86,22 +89,21 @@ const DocumentUpload = () => {
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Fichier (PDF uniquement)</label>
-              <input
-                type="file"
-                onChange={handleFileChange}
-                accept=".pdf"
-                multiple
-                className="w-full border border-gray-300 px-4 py-2 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 bg-gray-50"
-              />
+              <Dropzone onFiles={handleFilesChange} accept=".pdf" />
               {errors.files && (
                 <p className="mt-1 text-sm text-red-600">{errors.files}</p>
               )}
               {files.length > 0 && (
-                <ul className="mt-2 text-sm text-green-600 list-disc list-inside">
-                  {files.map((f) => (
-                    <li key={f.name}>{f.name}</li>
-                  ))}
-                </ul>
+                <div className="mt-2 text-sm text-green-600">
+                  {files.length} fichier(s) sélectionné(s)
+                  <button
+                    type="button"
+                    onClick={() => setIsModalOpen(true)}
+                    className="ml-2 text-blue-600 underline"
+                  >
+                    Voir les fichiers
+                  </button>
+                </div>
               )}
             </div>
 
@@ -116,6 +118,47 @@ const DocumentUpload = () => {
         </form>
       </div>
     </div>
+
+    <Modal
+      isOpen={isModalOpen}
+      onRequestClose={() => setIsModalOpen(false)}
+      ariaHideApp={false}
+      style={{
+        overlay: {
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000,
+        },
+        content: {
+          inset: 'auto',
+          position: 'relative',
+          border: 'none',
+          background: 'white',
+          borderRadius: '8px',
+          padding: '20px',
+          width: '100%',
+          maxWidth: '400px',
+          maxHeight: '80vh',
+          overflow: 'auto',
+        },
+      }}
+    >
+      <h2 className="text-lg font-bold mb-4">Fichiers sélectionnés</h2>
+      <ul className="list-disc list-inside mb-4">
+        {files.map((f) => (
+          <li key={f.name}>{f.name}</li>
+        ))}
+      </ul>
+      <button
+        onClick={() => setIsModalOpen(false)}
+        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+      >
+        Fermer
+      </button>
+    </Modal>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add reusable Dropzone component for drag-and-drop or tap file selection
- update document upload page to show count and modal preview of selected files

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching react-router-dom)*
- `pytest` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c0abf3aeb8833396a4c64567b8d446