### PR TITLE
Refactor envelope summary layout

### DIFF
--- a/frontend/src/pages/EnvelopeSent.js
+++ b/frontend/src/pages/EnvelopeSent.js
@@ -2,19 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import signatureService from '../services/signatureService';
 import SignatureNavbar from '../components/SignatureNavbar';
-import { 
-  CheckCircle, 
-  FileText, 
-  Users, 
-  Calendar, 
-  Eye, 
-  ArrowLeft,
-  Clock,
-  Mail,
-  User,
-  ExternalLink,
-  Download
-} from 'lucide-react';
+import { FileText, Users, ArrowLeft, Download, ChevronDown } from 'lucide-react';
+import slugify from 'slugify';
 import logService from '../services/logService';
 import sanitize from '../utils/sanitize';
 export default function EnvelopeSent() {
@@ -22,6 +11,9 @@ export default function EnvelopeSent() {
   const navigate = useNavigate();
   const [envelope, setEnvelope] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [showRecipients, setShowRecipients] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [downloading, setDownloading] = useState(false);
 
   useEffect(() => {
     const loadEnvelope = async () => {
@@ -94,6 +86,28 @@ export default function EnvelopeSent() {
   const totalRecipients = envelope.recipients?.length || 0;
   const progressPercentage = totalRecipients > 0 ? (signedCount / totalRecipients) * 100 : 0;
 
+  const handleDownload = async () => {
+    try {
+      setDownloading(true);
+      const { download_url } = await signatureService.downloadEnvelope(id);
+      const response = await fetch(download_url);
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      const safeName = slugify(envelope.title || 'document', { lower: true, strict: true });
+      link.download = `${safeName}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      logService.error(error);
+    } finally {
+      setDownloading(false);
+    }
+  };
+
   return (
     <div className="flex flex-col min-h-screen">
       <SignatureNavbar />
@@ -117,7 +131,6 @@ export default function EnvelopeSent() {
                 Votre document a été envoyé aux destinataires pour signature.
               </p>
             </div>
-            <CheckCircle className="w-12 h-12 text-green-500 shrink-0" />
           </div>
         </div>
 
@@ -129,106 +142,79 @@ export default function EnvelopeSent() {
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2">
                     <FileText className="w-5 h-5 text-blue-500" />
-                     <h2 className="text-xl font-semibold text-gray-900">{sanitize(envelope.title)}</h2>
+                    <h2 className="text-xl font-semibold text-gray-900">{sanitize(envelope.title)}</h2>
                   </div>
                   {getStatusBadge(envelope.status)}
                 </div>
-                
                 <div className="text-right">
                   <div className="text-sm text-gray-600 mb-1">Progression des signatures</div>
                   <div className="text-2xl font-bold text-gray-900">{signedCount}/{totalRecipients}</div>
                   <div className="w-32 bg-gray-200 rounded-full h-2 mt-2">
-                    <div 
+                    <div
                       className="bg-green-500 h-2 rounded-full transition-all duration-300"
                       style={{ width: `${progressPercentage}%` }}
                     />
                   </div>
                 </div>
               </div>
-
-              {/* Infos */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 {envelope.deadline_at && (
-                  <div className="flex items-center gap-3 p-4 bg-amber-50 rounded-lg">
-                    <Calendar className="w-5 h-5 text-amber-600" />
-                    <div>
-                      <p className="text-sm font-medium text-amber-800">Date limite</p>
-                      <p className="text-sm text-amber-700">
-                        {new Date(envelope.deadline_at).toLocaleDateString('fr-FR', {
-                          weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
-                        })}
-                      </p>
-                    </div>
-                  </div>
-                )}
-                
-                <div className="flex items-center gap-3 p-4 bg-blue-50 rounded-lg">
-                  <Clock className="w-5 h-5 text-blue-600" />
-                  <div>
-                    <p className="text-sm font-medium text-blue-800">Envoyé le</p>
-                    <p className="text-sm text-blue-700">
-                      {new Date(envelope.created_at || Date.now()).toLocaleDateString('fr-FR', {
-                        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
-                        hour: '2-digit', minute: '2-digit'
+                  <div className="p-4 bg-amber-50 rounded-lg">
+                    <p className="text-sm font-medium text-amber-800">Date limite</p>
+                    <p className="text-sm text-amber-700">
+                      {new Date(envelope.deadline_at).toLocaleDateString('fr-FR', {
+                        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
                       })}
                     </p>
                   </div>
+                )}
+                <div className="p-4 bg-blue-50 rounded-lg">
+                  <p className="text-sm font-medium text-blue-800">Envoyé le</p>
+                  <p className="text-sm text-blue-700">
+                    {new Date(envelope.created_at || Date.now()).toLocaleDateString('fr-FR', {
+                      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+                      hour: '2-digit', minute: '2-digit'
+                    })}
+                  </p>
                 </div>
               </div>
             </div>
-          </div>
-
-          {/* Liste des destinataires */}
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200">
-            <div className="px-6 py-4 border-b border-gray-200">
+            <button
+              onClick={() => setShowRecipients(!showRecipients)}
+              className="w-full flex items-center justify-between px-6 py-4 border-t border-gray-200 hover:bg-gray-50"
+            >
               <div className="flex items-center gap-3">
                 <Users className="w-5 h-5 text-gray-500" />
-                <h3 className="text-lg font-medium text-gray-900">
-                  Destinataires ({envelope.recipients?.length || 0})
-                </h3>
+                <span className="text-lg font-medium text-gray-900">
+                  Destinataires ({totalRecipients})
+                </span>
               </div>
-            </div>
-            
-            <div className="p-6">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {envelope.recipients?.map((recipient, index) => (
-                  <div 
-                    key={recipient.id || index}
-                    className={`p-4 rounded-lg border-2 transition-colors ${
-                      recipient.signed ? 'border-green-200 bg-green-50' : 'border-gray-200 bg-gray-50'
-                    }`}
-                  >
-                    <div className="flex items-start justify-between mb-3">
-                      <div className="flex items-center gap-3">
-                        <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
-                          recipient.signed ? 'bg-green-500 text-white' : 'bg-gray-300 text-gray-600'
-                        }`}>
-                          {recipient.signed ? <CheckCircle className="w-4 h-4" /> : <User className="w-4 h-4" />}
-                        </div>
-                        <div>
-                           <p className="font-medium text-gray-900">{sanitize(recipient.full_name)}</p>
-                          <div className="flex items-center gap-1 text-sm text-gray-600">
-                            <Mail className="w-3 h-3" />
-                            <span>{sanitize(recipient.email)}</span>
-                          </div>
-                        </div>
-                      </div>
-                      <span className={`text-xs font-medium px-2 py-1 rounded-full ${
-                        recipient.signed ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
-                      }`}>
+              <ChevronDown className={`w-5 h-5 transform transition-transform ${showRecipients ? 'rotate-180' : ''}`} />
+            </button>
+            {showRecipients && (
+              <div className="p-6 border-t border-gray-200">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {envelope.recipients?.map((recipient, index) => (
+                    <div
+                      key={recipient.id || index}
+                      className={`p-4 rounded-lg border-2 ${recipient.signed ? 'border-green-200 bg-green-50' : 'border-gray-200 bg-gray-50'}`}
+                    >
+                      <p className="font-medium text-gray-900">{sanitize(recipient.full_name)}</p>
+                      <p className="text-sm text-gray-600">{sanitize(recipient.email)}</p>
+                      <span className={`inline-block mt-2 text-xs font-medium px-2 py-1 rounded-full ${recipient.signed ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
                         {recipient.signed ? 'Signé' : 'En attente'}
                       </span>
+                      {recipient.signed && recipient.signed_at && (
+                        <p className="mt-2 text-xs text-green-700">
+                          Signé le {new Date(recipient.signed_at).toLocaleDateString('fr-FR')} à{' '}
+                          {new Date(recipient.signed_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
+                        </p>
+                      )}
                     </div>
-                    {recipient.signed && recipient.signed_at && (
-                      <p className="text-xs text-green-700">
-                        Signé le {new Date(recipient.signed_at).toLocaleDateString('fr-FR')} à {' '}
-                        {new Date(recipient.signed_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
-                      </p>
-                    )}
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
           {/* Documents envoyés */}
@@ -244,28 +230,15 @@ export default function EnvelopeSent() {
                 <ul className="space-y-2">
                   {envelope.documents.map(doc => (
                     <li key={doc.id} className="flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <FileText className="w-4 h-4 text-gray-500" />
-                        <span className="text-sm">{doc.name || `Document ${doc.id}`}</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <a
-                          href={doc.file_url}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-sm text-blue-600 hover:underline inline-flex items-center gap-1"
-                        >
-                          Ouvrir <ExternalLink className="w-3 h-3" />
-                        </a>
-                        <a
-                          href={doc.file_url}
-                          download
-                          className="text-sm text-gray-700 hover:underline inline-flex items-center gap-1"
-                        >
-                          <Download className="w-3 h-3" />
-                          Télécharger
-                        </a>
-                      </div>
+                      <span className="text-sm">{doc.name || `Document ${doc.id}`}</span>
+                      <a
+                        href={doc.file_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-sm text-blue-600 hover:underline"
+                      >
+                        Ouvrir
+                      </a>
                     </li>
                   ))}
                 </ul>
@@ -277,22 +250,39 @@ export default function EnvelopeSent() {
 
           {/* Actions */}
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Actions disponibles</h3>
-            <div className="flex flex-col sm:flex-row gap-3">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
               <button
-                onClick={() => navigate(`/signature/detail/${id}`)}
-                className="inline-flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                onClick={handleDownload}
+                disabled={downloading}
+                className="inline-flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
               >
-                <Eye className="w-4 h-4 mr-2" />
-                Voir le document
+                <Download className="w-4 h-4 mr-2" />
+                {downloading ? 'Téléchargement...' : 'Télécharger le PDF'}
               </button>
-              <button
-                onClick={() => navigate('/dashboard')}
-                className="inline-flex items-center justify-center px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors"
-              >
-                <ArrowLeft className="w-4 h-4 mr-2" />
-                Retour au tableau de bord
-              </button>
+              <div className="relative">
+                <button
+                  onClick={() => setMenuOpen(!menuOpen)}
+                  className="px-4 py-2 border rounded-lg text-gray-700 hover:bg-gray-50"
+                >
+                  Autres actions
+                </button>
+                {menuOpen && (
+                  <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
+                    <button
+                      onClick={() => navigate(`/signature/detail/${id}`)}
+                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    >
+                      Voir le document
+                    </button>
+                    <button
+                      onClick={() => navigate('/dashboard')}
+                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                    >
+                      Retour au tableau de bord
+                    </button>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Split envelope details into summary and collapsible recipients
- Simplify icon usage across sections
- Add prominent PDF download button with secondary action menu

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c173e32b648333ba49d4a2cd5640cd