### PR TITLE
Simplify signature confirmation pages

### DIFF
--- a/frontend/src/pages/GuestSignatureConfirmation.js
+++ b/frontend/src/pages/GuestSignatureConfirmation.js
@@ -1,48 +1,29 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { CheckCircle, Download, RefreshCw } from 'lucide-react';
 import signatureService from '../services/signatureService';
-import {
-  CheckCircle,
-  Download,
-  FileText,
-  Clock,
-  RefreshCw,
-  Sparkles,
-  Shield,
-  ExternalLink,
-  Mail,
-  User,
-  Calendar,
-  Award
-} from 'lucide-react';
 import logService from '../services/logService';
 import sanitize from '../utils/sanitize';
+
 const GuestSignatureConfirmation = () => {
-  const navigate = useNavigate();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const [downloading, setDownloading] = useState(false);
   const [envelope, setEnvelope] = useState(null);
-  const [loadingEnv, setLoadingEnv] = useState(true);
 
   const envelopeId = location.state?.id || searchParams.get('id');
   const token = searchParams.get('token');
 
   useEffect(() => {
     const load = async () => {
-      if (!envelopeId || !token) { 
-        setLoadingEnv(false); 
-        return; 
-      }
+      if (!envelopeId || !token) return;
       try {
         const data = await signatureService.getGuestEnvelope(envelopeId, token);
         setEnvelope(data);
       } catch (e) {
         logService.error(e);
-        toast.error('Impossible de charger les informations du document');
-      } finally {
-        setLoadingEnv(false);
+        toast.error("Impossible de charger les informations du document");
       }
     };
     load();
@@ -77,230 +58,31 @@ const GuestSignatureConfirmation = () => {
     }
   };
 
-  const formatDate = (dateString) => {
-    if (!dateString) return new Date().toLocaleDateString('fr-FR');
-    return new Date(dateString).toLocaleDateString('fr-FR', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  };
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-blue-50">
-      {/* Header simple pour invités */}
-      <header className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
-                <FileText className="w-5 h-5 text-white" />
-              </div>
-              <span className="text-xl font-semibold text-gray-900">Signature Électronique</span>
-            </div>
-            <div className="hidden sm:flex items-center gap-2 text-sm text-gray-600">
-              <Shield className="w-4 h-4" />
-              <span>Signature sécurisée</span>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      {/* Contenu principal */}
-      <main className="flex-1 p-4 lg:p-8">
-        <div className="max-w-3xl mx-auto">
-          {/* Animation de succès */}
-          <div className="text-center mb-8">
-            <div className="relative inline-block">
-              <div className="absolute inset-0 animate-ping rounded-full bg-green-200 opacity-75"></div>
-              <div className="relative bg-green-500 rounded-full p-6">
-                <CheckCircle className="w-16 h-16 text-white" />
-              </div>
-            </div>
-            <div className="mt-6">
-              <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 mb-3">
-                Signature réussie !
-              </h1>
-              <p className="text-lg sm:text-xl text-gray-600 max-w-2xl mx-auto">
-                Félicitations ! Votre signature électronique a été enregistrée avec succès. 
-                Le document est maintenant légalement signé.
-              </p>
-            </div>
-          </div>
-
-          {/* Carte principale */}
-          <div className="bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden mb-8">
-            {/* En-tête coloré */}
-            <div className="bg-gradient-to-r from-green-500 via-green-600 to-blue-600 p-6 sm:p-8 text-white relative overflow-hidden">
-              <div className="absolute top-0 right-0 opacity-20">
-                <Sparkles className="w-32 h-32 sm:w-40 sm:h-40" />
-              </div>
-              <div className="relative z-10">
-                <div className="flex items-center gap-3 mb-3">
-                  <Award className="w-6 h-6" />
-                  <span className="text-sm sm:text-base font-medium opacity-90">
-                    Signature électronique certifiée
-                  </span>
-                </div>
-                <h2 className="text-xl sm:text-2xl font-bold mb-2">
-                  {envelope?.title || 'Document signé avec succès'}
-                </h2>
-                <p className="text-sm sm:text-base opacity-90">
-                  Votre signature numérique est juridiquement valable et conforme aux standards de sécurité.
-                </p>
-              </div>
-            </div>
-
-            {/* Contenu de la carte */}
-            <div className="p-6 sm:p-8 space-y-6">
-              {/* Informations du document */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="flex items-center gap-4 p-4 bg-green-50 rounded-xl">
-                  <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
-                    <CheckCircle className="w-5 h-5 text-green-600" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-semibold text-green-800">Statut</p>
-                    <p className="text-sm text-green-700">Signature complétée</p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-4 p-4 bg-blue-50 rounded-xl">
-                  <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-                    <Clock className="w-5 h-5 text-blue-600" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-semibold text-blue-800">Date de signature</p>
-                    <p className="text-sm text-blue-700">
-                      {formatDate(envelope?.signed_at)}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Informations du signataire */}
-              {envelope && (
-                <div className="bg-gray-50 rounded-xl p-4 sm:p-6">
-                  <h3 className="font-semibold text-gray-900 mb-4 flex items-center gap-2">
-                    <User className="w-5 h-5" />
-                    Informations du signataire
-                  </h3>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-                    {envelope.recipient_name && (
-                      <div>
-                        <span className="font-medium text-gray-700">Nom : </span>
-                        <span className="text-gray-900">{envelope.recipient_name}</span>
-                      </div>
-                    )}
-                    {envelope.recipient_email && (
-                      <div className="flex items-center gap-2">
-                        <Mail className="w-4 h-4 text-gray-500" />
-                        <span className="text-gray-900">{envelope.recipient_email}</span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Actions principales */}
-              <div className="space-y-4">
-                {envelopeId && token && (
-                  <button
-                    onClick={handleDownload}
-                    disabled={downloading}
-                    className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-blue-600 text-white rounded-xl hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-sm hover:shadow-lg text-base font-semibold"
-                  >
-                    {downloading ? (
-                      <>
-                        <RefreshCw className="w-5 h-5 animate-spin" />
-                        Téléchargement en cours...
-                      </>
-                    ) : (
-                      <>
-                        <Download className="w-5 h-5" />
-                        Télécharger le document signé
-                      </>
-                    )}
-                  </button>
-                )}
-
-                {/* Documents de l'enveloppe pour invités */}
-                {!loadingEnv && envelope?.documents?.length > 0 && (
-                  <div className="bg-gray-50 rounded-xl p-4 sm:p-6">
-                    <h3 className="font-semibold text-gray-900 mb-4">
-                      Document{envelope.documents.length > 1 ? 's' : ''} de l'enveloppe
-                    </h3>
-                    <div className="space-y-3">
-                      {envelope.documents.map(doc => (
-                        <div key={doc.id} className="flex items-center justify-between p-3 bg-white rounded-lg border">
-                          <div className="flex items-center gap-3">
-                            <div className="w-8 h-8 bg-blue-100 rounded-lg flex items-center justify-center">
-                              <FileText className="w-4 h-4 text-blue-600" />
-                            </div>
-                            <span className="text-sm font-medium text-gray-900">
-                              {doc.name || `Document ${doc.id}`}
-                            </span>
-                          </div>
-                          {doc.file_url && (
-                            <div className="flex items-center gap-2">
-                              <a
-                                href={doc.file_url}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-sm text-blue-600 hover:text-blue-800 inline-flex items-center gap-1 font-medium"
-                              >
-                                Ouvrir
-                                <ExternalLink className="w-3 h-3" />
-                              </a>
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* Informations légales */}
-          <div className="bg-white rounded-xl border border-gray-200 p-6 shadow-sm">
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center flex-shrink-0">
-                <Shield className="w-5 h-5 text-green-600" />
-              </div>
-              <div>
-                <h3 className="font-semibold text-gray-900 mb-2">Validité juridique</h3>
-                <p className="text-sm text-gray-600 leading-relaxed">
-                  Cette signature électronique est juridiquement valable selon les réglementations en vigueur 
-                  (Règlement eIDAS, Code civil). Elle a la même valeur qu'une signature manuscrite et engage 
-                  juridiquement le signataire.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Informations de contact ou support */}
-          <div className="mt-8 text-center">
-            <p className="text-sm text-gray-500 mb-2">
-              Vous avez des questions sur ce document ?
-            </p>
-            <p className="text-xs text-gray-400">
-              Conservez ce lien pour pouvoir télécharger à nouveau le document signé.
-            </p>
-          </div>
-
-          {/* Footer minimaliste */}
-          <footer className="mt-12 pt-8 border-t border-gray-200 text-center">
-            <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
-              <Shield className="w-4 h-4" />
-              <span>Signature électronique sécurisée - Tous droits réservés</span>
-            </div>
-          </footer>
-        </div>
-      </main>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="bg-white rounded-lg shadow-md p-8 text-center">
+        <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold mb-6">Signature réussie&nbsp;!</h1>
+        {envelopeId && token && (
+          <button
+            onClick={handleDownload}
+            disabled={downloading}
+            className="flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 mx-auto"
+          >
+            {downloading ? (
+              <>
+                <RefreshCw className="w-5 h-5 animate-spin" />
+                Téléchargement...
+              </>
+            ) : (
+              <>
+                <Download className="w-5 h-5" />
+                Télécharger
+              </>
+            )}
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/SignatureConfirmation.js
+++ b/frontend/src/pages/SignatureConfirmation.js
@@ -1,47 +1,17 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { CheckCircle, Download, RefreshCw } from 'lucide-react';
 import signatureService from '../services/signatureService';
 import SignatureNavbar from '../components/SignatureNavbar';
-import {
-  CheckCircle,
-  Download,
-  FileText,
-  ArrowRight,
-  Clock,
-  Home,
-  RefreshCw,
-  Sparkles,
-  Shield,
-  ExternalLink
-} from 'lucide-react';
 import logService from '../services/logService';
 
 const SignatureConfirmation = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const [searchParams] = useSearchParams();
   const [downloading, setDownloading] = useState(false);
-  const [countdown, setCountdown] = useState(10);
-  const [envelope, setEnvelope] = useState(null);
-  const [loadingEnv, setLoadingEnv] = useState(true);
 
-  const envelopeId = location.state?.id || searchParams.get('id');
-
-  useEffect(() => {
-    const load = async () => {
-      if (!envelopeId) { setLoadingEnv(false); return; }
-      try {
-        const data = await signatureService.getEnvelope(envelopeId);
-        setEnvelope(data);
-      } catch (e) {
-        logService.error(e);
-      } finally {
-        setLoadingEnv(false);
-      }
-    };
-    load();
-  }, [envelopeId]);
+  const envelopeId = location.state?.id || new URLSearchParams(location.search).get('id');
 
   const handleDownload = async () => {
     if (!envelopeId) {
@@ -72,210 +42,37 @@ const SignatureConfirmation = () => {
   };
 
   useEffect(() => {
-    const timer = setInterval(() => {
-      setCountdown(prev => {
-        if (prev <= 1) {
-          navigate('/signature/envelopes/completed');
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => clearInterval(timer);
+    const timer = setTimeout(() => navigate('/signature/envelopes/completed'), 10000);
+    toast.info('Redirection vers "Mes documents signés" dans 10 secondes');
+    return () => clearTimeout(timer);
   }, [navigate]);
-
-  const handleStayOnPage = () => setCountdown(-1);
-  const handleRedirectNow = () => navigate('/signature/envelopes/completed');
 
   return (
     <div className="flex flex-col min-h-screen">
       <SignatureNavbar />
-      <main className="flex-1 bg-gradient-to-br from-green-50 via-white to-blue-50 p-4 lg:p-8">
-        <div className="max-w-2xl mx-auto">
-          {/* Animation de succès */}
-          <div className="text-center mb-8">
-            <div className="relative inline-block">
-              <div className="absolute inset-0 animate-ping rounded-full bg-green-200 opacity-75"></div>
-              <div className="relative bg-green-500 rounded-full p-4">
-                <CheckCircle className="w-12 h-12 text-white" />
-              </div>
-            </div>
-            <div className="mt-4">
-              <h1 className="text-3xl lg:text-4xl font-bold text-gray-900 mb-2">
-                Signature confirmée !
-              </h1>
-              <p className="text-lg text-gray-600">
-                Félicitations, votre signature a été enregistrée avec succès.
-              </p>
-            </div>
-          </div>
-
-          {/* Carte principale */}
-          <div className="bg-white rounded-xl shadow-lg border border-gray-100 overflow-hidden mb-6">
-            <div className="bg-gradient-to-r from-green-500 to-blue-600 p-6 text-white relative overflow-hidden">
-              <div className="absolute top-0 right-0 opacity-20">
-                <Sparkles className="w-32 h-32" />
-              </div>
-              <div className="relative z-10">
-                <div className="flex items-center gap-3 mb-2">
-                  <Shield className="w-6 h-6" />
-                  <span className="text-sm font-medium opacity-90">Signature sécurisée</span>
-                </div>
-                <h2 className="text-xl font-semibold">Document signé numériquement</h2>
-                <p className="text-sm opacity-90 mt-1">
-                  Votre signature électronique est juridiquement valable et sécurisée.
-                </p>
-              </div>
-            </div>
-
-            <div className="p-6 space-y-6">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="flex items-center gap-3 p-4 bg-green-50 rounded-lg">
-                  <CheckCircle className="w-5 h-5 text-green-600" />
-                  <div>
-                    <p className="text-sm font-medium text-green-800">Statut</p>
-                    <p className="text-sm text-green-700">Signature complétée</p>
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-3 p-4 bg-blue-50 rounded-lg">
-                  <Clock className="w-5 h-5 text-blue-600" />
-                  <div>
-                    <p className="text-sm font-medium text-blue-800">Horodatage</p>
-                    <p className="text-sm text-blue-700">
-                      {new Date().toLocaleDateString('fr-FR', {
-                        hour: '2-digit', minute: '2-digit', second: '2-digit'
-                      })}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Actions principales */}
-              <div className="space-y-3">
-                {envelopeId && (
-                  <button
-                    onClick={handleDownload}
-                    disabled={downloading}
-                    className="w-full flex items-center justify-center gap-3 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-sm hover:shadow-md"
-                  >
-                    {downloading ? (
-                      <>
-                        <RefreshCw className="w-5 h-5 animate-spin" />
-                        Téléchargement en cours...
-                      </>
-                    ) : (
-                      <>
-                        <Download className="w-5 h-5" />
-                        Télécharger le document signé
-                      </>
-                    )}
-                  </button>
-                )}
-
-                {/* Si multi-docs, proposer aussi l'accès à chaque PDF original */}
-                {!loadingEnv && envelope?.documents?.length > 0 && (
-                  <div className="bg-gray-50 rounded-lg p-4">
-                    <div className="font-medium text-gray-900 mb-2">Documents de l’enveloppe</div>
-                    <ul className="space-y-2">
-                      {envelope.documents.map(doc => (
-                        <li key={doc.id} className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <FileText className="w-4 h-4 text-gray-500" />
-                            <span className="text-sm">{doc.name || `Document ${doc.id}`}</span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <a
-                              href={doc.file_url}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="text-sm text-blue-600 hover:underline inline-flex items-center gap-1"
-                            >
-                              Ouvrir <ExternalLink className="w-3 h-3" />
-                            </a>
-                            <a
-                              href={doc.file_url}
-                              download
-                              className="text-sm text-gray-700 hover:underline"
-                            >
-                              Télécharger
-                            </a>
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Link 
-                    to="/signature/envelopes/completed"
-                    className="flex items-center justify-center gap-2 px-4 py-3 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm font-medium"
-                  >
-                    <FileText className="w-4 h-4" />
-                    Mes documents
-                  </Link>
-                  <Link 
-                    to="/dashboard"
-                    className="flex items-center justify-center gap-2 px-4 py-3 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm font-medium"
-                  >
-                    <Home className="w-4 h-4" />
-                    Tableau de bord
-                  </Link>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Redirection auto */}
-          {countdown > 0 && (
-            <div className="bg-white rounded-lg border border-amber-200 p-4 shadow-sm">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-amber-100 rounded-full flex items-center justify-center">
-                    <Clock className="w-4 h-4 text-amber-600" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium text-amber-800">
-                      Redirection automatique dans {countdown} seconde{countdown !== 1 ? 's' : ''}
-                    </p>
-                    <p className="text-xs text-amber-700">
-                      Vers la page "Mes documents signés"
-                    </p>
-                  </div>
-                </div>
-                <div className="flex gap-2">
-                  <button
-                    onClick={handleStayOnPage}
-                    className="text-xs px-3 py-1 text-amber-700 border border-amber-300 rounded hover:bg-amber-50 transition-colors"
-                  >
-                    Rester ici
-                  </button>
-                  <button
-                    onClick={handleRedirectNow}
-                    className="text-xs px-3 py-1 bg-amber-600 text-white rounded hover:bg-amber-700 transition-colors flex items-center gap-1"
-                  >
-                    Y aller
-                    <ArrowRight className="w-3 h-3" />
-                  </button>
-                </div>
-              </div>
-              <div className="mt-3">
-                <div className="w-full bg-amber-100 rounded-full h-1">
-                  <div 
-                    className="bg-amber-500 h-1 rounded-full transition-all duration-1000"
-                    style={{ width: `${((10 - countdown) / 10) * 100}%` }}
-                  />
-                </div>
-              </div>
-            </div>
+      <main className="flex-1 flex items-center justify-center bg-gray-50 p-4">
+        <div className="bg-white rounded-lg shadow-md p-8 text-center">
+          <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <h1 className="text-2xl font-bold mb-6">Signature confirmée&nbsp;!</h1>
+          {envelopeId && (
+            <button
+              onClick={handleDownload}
+              disabled={downloading}
+              className="flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 mx-auto"
+            >
+              {downloading ? (
+                <>
+                  <RefreshCw className="w-5 h-5 animate-spin" />
+                  Téléchargement...
+                </>
+              ) : (
+                <>
+                  <Download className="w-5 h-5" />
+                  Télécharger
+                </>
+              )}
+            </button>
           )}
-
-          <div className="mt-8 text-center text-xs text-gray-500">
-            <p>
-              Cette signature électronique est juridiquement valable selon les réglementations en vigueur.
-            </p>
-          </div>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Streamline guest signature confirmation to a simple success block with download button
- Simplify signed user confirmation page and move auto-redirect countdown into toast

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c19654cdc883338758eb22bdf97f83