### PR TITLE
feat(frontend): improve reset password form

### DIFF
--- a/frontend/src/pages/ResetPasswordConfirmPage.js
+++ b/frontend/src/pages/ResetPasswordConfirmPage.js
@@ -1,25 +1,34 @@
 import React, { useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import signatureService from '../services/signatureService';
+import { Eye, EyeOff } from 'lucide-react';
+import { passwordChangeSchema } from '../validation/schemas';
 
 const ResetPasswordConfirmPage = () => {
   const { uid, token } = useParams();
   const navigate = useNavigate();
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
+  const [errors, setErrors] = useState({});
   const [message, setMessage] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const onSubmit = async (e) => {
     e.preventDefault();
-    if (!password || password.length < 5) {
-      setMessage('Le mot de passe doit contenir au moins 5 caractères.');
-      return;
+    const newErrors = {};
+    try {
+      passwordChangeSchema.fields.new_password.validateSync(password);
+    } catch (err) {
+      newErrors.password = err.message;
     }
     if (password !== confirm) {
-      setMessage('Les mots de passe ne correspondent pas.');
-      return;
+      newErrors.confirm = 'Les mots de passe ne correspondent pas.';
     }
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
+
     setSubmitting(true);
     setMessage('');
     try {
@@ -29,6 +38,32 @@ const ResetPasswordConfirmPage = () => {
       setMessage(err?.message || 'Impossible de changer le mot de passe. Le lien est peut-être expiré.');
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handlePasswordChange = (e) => {
+    const value = e.target.value;
+    setPassword(value);
+    try {
+      passwordChangeSchema.fields.new_password.validateSync(value);
+      setErrors((prev) => ({ ...prev, password: undefined }));
+    } catch (err) {
+      setErrors((prev) => ({ ...prev, password: err.message }));
+    }
+    if (confirm && value !== confirm) {
+      setErrors((prev) => ({ ...prev, confirm: 'Les mots de passe ne correspondent pas.' }));
+    } else {
+      setErrors((prev) => ({ ...prev, confirm: undefined }));
+    }
+  };
+
+  const handleConfirmChange = (e) => {
+    const value = e.target.value;
+    setConfirm(value);
+    if (password && value !== password) {
+      setErrors((prev) => ({ ...prev, confirm: 'Les mots de passe ne correspondent pas.' }));
+    } else {
+      setErrors((prev) => ({ ...prev, confirm: undefined }));
     }
   };
 
@@ -49,32 +84,66 @@ const ResetPasswordConfirmPage = () => {
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium mb-1">Nouveau mot de passe</label>
-          <input
-            type="password"
-            className="w-full border rounded px-3 py-2"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            autoComplete="new-password"
-            required
-            minLength={5}
-          />
+          <div className="relative">
+            <input
+              type={showPassword ? 'text' : 'password'}
+              className="w-full border rounded px-3 py-2 pr-10"
+              value={password}
+              onChange={handlePasswordChange}
+              autoComplete="new-password"
+              required
+              minLength={5}
+            />
+            <button
+              type="button"
+              className="absolute inset-y-0 right-0 px-3 flex items-center"
+              onClick={() => setShowPassword(!showPassword)}
+              aria-label={showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+            >
+              {showPassword ? (
+                <EyeOff className="h-5 w-5 text-gray-500" />
+              ) : (
+                <Eye className="h-5 w-5 text-gray-500" />
+              )}
+            </button>
+          </div>
+          {errors.password && (
+            <p className="mt-1 text-sm text-red-600">{errors.password}</p>
+          )}
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Confirmer le mot de passe</label>
-          <input
-            type="password"
-            className="w-full border rounded px-3 py-2"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            autoComplete="new-password"
-            required
-            minLength={5}
-          />
+          <div className="relative">
+            <input
+              type={showConfirm ? 'text' : 'password'}
+              className="w-full border rounded px-3 py-2 pr-10"
+              value={confirm}
+              onChange={handleConfirmChange}
+              autoComplete="new-password"
+              required
+              minLength={5}
+            />
+            <button
+              type="button"
+              className="absolute inset-y-0 right-0 px-3 flex items-center"
+              onClick={() => setShowConfirm(!showConfirm)}
+              aria-label={showConfirm ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+            >
+              {showConfirm ? (
+                <EyeOff className="h-5 w-5 text-gray-500" />
+              ) : (
+                <Eye className="h-5 w-5 text-gray-500" />
+              )}
+            </button>
+          </div>
+          {errors.confirm && (
+            <p className="mt-1 text-sm text-red-600">{errors.confirm}</p>
+          )}
         </div>
 
         <button
           type="submit"
-          disabled={submitting}
+          disabled={submitting || !password || !confirm || errors.password || errors.confirm}
           className="w-full rounded bg-black text-white py-2 disabled:opacity-60"
         >
           {submitting ? 'Mise à jour…' : 'Mettre à jour le mot de passe'}


### PR DESCRIPTION
## Summary
- add show/hide toggles for reset password fields
- validate new password with passwordChangeSchema and display field errors

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c173a52fc483339ebb00fb1d7185f7