### PR TITLE
Use native page dimensions for signature placement ratios

### DIFF
--- a/frontend/src/pages/BulkSignSameWizard.js
+++ b/frontend/src/pages/BulkSignSameWizard.js
@@ -119,15 +119,16 @@ export default function BulkSignSameWizard() {
     if (!placing) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const scale = pageScale(pageNumber);
-    const pageHeightPx = (pageDims[pageNumber]?.height || 0) * scale;
-    const x = (e.clientX - rect.left) / pageWidth;
-    const y = (e.clientY - rect.top) / pageHeightPx;
+    const natWidth = pageDims[pageNumber]?.width || 1;
+    const natHeight = pageDims[pageNumber]?.height || 1;
+    const xNative = (e.clientX - rect.left) / scale;
+    const yNative = (e.clientY - rect.top) / scale;
     setPlacement({
       page: pageNumber,
-      x,
-      y,
-      width: 160 / pageWidth,
-      height: 50 / pageHeightPx,
+      x: xNative / natWidth,
+      y: yNative / natHeight,
+      width: 160 / natWidth,
+      height: 50 / natHeight,
     });
     setPlacing(false);
     toast.success(`Zone définie (page ${pageNumber}) — appliquée à tous les documents`);

--- a/frontend/src/pages/DocumentWorkflow.js
+++ b/frontend/src/pages/DocumentWorkflow.js
@@ -776,15 +776,15 @@ export default function DocumentWorkflow() {
       return;
     }
     const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
     const vp = pageDimensions[selectedDocId]?.[pageNumber] || { width: 600, height: 800 };
-    const pdfHeight = (vp.height / vp.width) * pdfWidth;
+    const scale = pdfWidth / vp.width;
+    const xNative = (e.clientX - rect.left) / scale;
+    const yNative = (e.clientY - rect.top) / scale;
     const normalized = {
-      x: x / pdfWidth,
-      y: y / pdfHeight,
-      width: 150 / pdfWidth,
-      height: 50 / pdfHeight,
+      x: xNative / vp.width,
+      y: yNative / vp.height,
+      width: 150 / vp.width,
+      height: 50 / vp.height,
     };
     setFields((prev) =>
       prev.filter(

--- a/frontend/src/pages/SelfSignWizard.js
+++ b/frontend/src/pages/SelfSignWizard.js
@@ -111,15 +111,16 @@ export default function SelfSignWizard() {
     if (!placing) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const scale = pageScale(pageNumber);
-    const pageHeightPx = (pageDims[pageNumber]?.height || 0) * scale;
-    const x = (e.clientX - rect.left) / pageWidth;
-    const y = (e.clientY - rect.top) / pageHeightPx;
+    const natWidth = pageDims[pageNumber]?.width || 1;
+    const natHeight = pageDims[pageNumber]?.height || 1;
+    const xNative = (e.clientX - rect.left) / scale;
+    const yNative = (e.clientY - rect.top) / scale;
     setPlacement({
       page: pageNumber,
-      x,
-      y,
-      width: 160 / pageWidth,
-      height: 50 / pageHeightPx,
+      x: xNative / natWidth,
+      y: yNative / natHeight,
+      width: 160 / natWidth,
+      height: 50 / natHeight,
     });
     setPlacing(false);
     toast.success(`Zone posée p.${pageNumber}`);


### PR DESCRIPTION
## Summary
- Normalize signature placement in DocumentWorkflow using native page dimensions
- Compute self-sign and bulk placement ratios from natural PDF size
- Confirm backend validates position ratios between 0 and 1

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a6e192c48333851e58853cb3c3fd