### PR TITLE
Simplify auth layouts and unify status banners

### DIFF
--- a/frontend/src/components/StatusBanner.js
+++ b/frontend/src/components/StatusBanner.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import Alert from './Alert';
+
+const StatusBanner = () => {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const activated = params.get('activated');
+  const reset = params.get('reset');
+
+  if (activated === '1') {
+    return (
+      <Alert type="success">
+        Compte activé avec succès. Vous pouvez maintenant vous connecter.
+      </Alert>
+    );
+  }
+
+  if (activated === '0') {
+    return (
+      <Alert type="error">
+        Lien d'activation invalide. Veuillez vérifier votre lien ou en demander un nouveau.
+      </Alert>
+    );
+  }
+
+  if (reset === '1') {
+    return (
+      <Alert type="success">
+        Mot de passe réinitialisé avec succès. Vous pouvez maintenant vous connecter.
+      </Alert>
+    );
+  }
+
+  return null;
+};
+
+export default StatusBanner;

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -4,14 +4,12 @@ import { useAuth } from '../AuthContext';
 import { useLocation, Link } from 'react-router-dom';
 import { Mail, Lock, Loader2 } from 'lucide-react';
 import Alert from '../components/Alert';
+import StatusBanner from '../components/StatusBanner';
 import { loginSchema } from '../validation/schemas';
 
 const LoginPage = () => {
   const { login, authLoading } = useAuth();
   const location = useLocation();
-  const params = new URLSearchParams(location.search);
-  const activated = params.get('activated');
-  const reset = params.get('reset');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -42,7 +40,7 @@ const LoginPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-6 px-4 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-xl flex items-center justify-center">
@@ -58,25 +56,8 @@ const LoginPage = () => {
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow-xl sm:rounded-2xl sm:px-10 border border-gray-100">
-          {/* Messages d'état */}
-          {activated === '1' && (
-            <Alert type="success">
-              Compte activé avec succès. Vous pouvez maintenant vous connecter.
-            </Alert>
-          )}
-
-          {activated === '0' && (
-            <Alert type="error">
-              Lien d'activation invalide. Veuillez vérifier votre lien ou en demander un nouveau.
-            </Alert>
-          )}
-
-          {reset === '1' && (
-            <Alert type="success">
-              Mot de passe réinitialisé avec succès. Vous pouvez maintenant vous connecter.
-            </Alert>
-          )}
+        <div className="bg-white py-6 px-4 shadow-xl sm:rounded-2xl sm:px-8 border border-gray-100">
+          <StatusBanner />
 
           {error && <Alert type="error">{error}</Alert>}
 

--- a/frontend/src/pages/PasswordResetPage.js
+++ b/frontend/src/pages/PasswordResetPage.js
@@ -59,7 +59,7 @@ useEffect(() => {
     }
   };
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-6 px-4 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-xl flex items-center justify-center">
@@ -75,7 +75,7 @@ useEffect(() => {
       </div>
 
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white py-8 px-4 shadow-xl sm:rounded-2xl sm:px-10 border border-gray-100">
+        <div className="bg-white py-6 px-4 shadow-xl sm:rounded-2xl sm:px-8 border border-gray-100">
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* Email */}
             <div>

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -131,9 +131,9 @@ const handleResendEmail = async () => {
   };
   if (success) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-emerald-100 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-6 px-4 sm:px-6 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
-          <div className="bg-white py-8 px-4 shadow-xl sm:rounded-2xl sm:px-10 border border-gray-100 text-center">
+          <div className="bg-white py-6 px-4 shadow-xl sm:rounded-2xl sm:px-8 border border-gray-100 text-center">
             <div className="mx-auto h-16 w-16 bg-green-500 rounded-full flex items-center justify-center mb-6">
               <CheckCircle className="h-8 w-8 text-white" />
             </div>
@@ -174,7 +174,7 @@ const handleResendEmail = async () => {
   const errorMessages = Object.values(errors).flat().filter(Boolean);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-100 py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 py-6 px-4 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-2xl">
         <div className="text-center mb-8">
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-xl flex items-center justify-center">
@@ -211,7 +211,7 @@ const handleResendEmail = async () => {
           </div>
         </div>
 
-        <div className="bg-white py-8 px-4 shadow-xl sm:rounded-2xl sm:px-10 border border-gray-100">
+        <div className="bg-white py-6 px-4 shadow-xl sm:rounded-2xl sm:px-8 border border-gray-100">
           {/* Messages d'erreur */}
           {message && (
             <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-xl flex items-start space-x-3">


### PR DESCRIPTION
## Summary
- replace gradient backgrounds on auth pages with plain gray backdrop
- reduce padding to limit scrolling on small screens
- add reusable `StatusBanner` to show activation and reset messages on login

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6e7935883339e763dc87b89ca40