### PR TITLE
Expose cancelled_at on envelope list and show purge countdown

### DIFF
--- a/backend/signature/serializers.py
+++ b/backend/signature/serializers.py
@@ -267,6 +267,7 @@ class EnvelopeSerializer(serializers.ModelSerializer):
             'completion_rate',
             'jwt_token',
             'expires_at',
+            'cancelled_at',
         ]
         read_only_fields = [
             'hash_original',
@@ -277,6 +278,7 @@ class EnvelopeSerializer(serializers.ModelSerializer):
             'file_size',
             'file_type',
             'completion_rate',
+            'cancelled_at',
         ]
 
     def get_created_by_name(self, obj):


### PR DESCRIPTION
## Summary
- expose the `cancelled_at` timestamp through the envelope serializer so the list API returns it
- compute the remaining grace period for deleted envelopes in the UI and display it with an urgent badge when necessary

## Testing
- python -m compileall signature

------
https://chatgpt.com/codex/tasks/task_e_68c95dc0182c83338bb4704cd10bd1c6