### PR TITLE
Use envelope public IDs in front-end flows

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -84,9 +84,9 @@ const App = () => {
           <Route path="/signature/saved-signatures" element={<SavedSignaturesPage />} />
           
           <Route path="/signature/upload" element={<DocumentUpload />} />
-          <Route path="/signature/detail/:id" element={<DocumentDetail />} />
-          <Route path="/signature/workflow/:id" element={<DocumentWorkflow />} />
-          <Route path="/signature/sent/:id" element={<EnvelopeSent />} />
+          <Route path="/signature/detail/:publicId" element={<DocumentDetail />} />
+          <Route path="/signature/workflow/:publicId" element={<DocumentWorkflow />} />
+          <Route path="/signature/sent/:publicId" element={<EnvelopeSent />} />
           <Route path="/signature/envelopes/:publicId/sign" element={<DocumentSign />} />
           <Route path="/signature/sign/:publicId" element={<DocumentSign />} />
           <Route path="/settings/notifications" element={<NotificationSettings />} />

--- a/frontend/src/components/CompletedEnvelopes.js
+++ b/frontend/src/components/CompletedEnvelopes.js
@@ -110,13 +110,13 @@ const CompletedEnvelopes = () => {
     };
   };
 
-  const handlePreview = (id) => {
-    navigate(`/signature/detail/${id}`);
+  const handlePreview = (publicId) => {
+    navigate(`/signature/detail/${publicId}`);
   };
 
-  const handleDownload = async (id, title) => {
+  const handleDownload = async (publicId, title) => {
     try {
-      const { download_url } = await signatureService.downloadEnvelope(id);
+      const { download_url } = await signatureService.downloadEnvelope(publicId);
       const response = await fetch(download_url);
       const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
@@ -138,9 +138,9 @@ const CompletedEnvelopes = () => {
     }
   };
 
-  const handlePrint = async (id) => {
+  const handlePrint = async (publicId) => {
     try {
-      const { download_url } = await signatureService.downloadEnvelope(id);
+      const { download_url } = await signatureService.downloadEnvelope(publicId);
       const printWindow = window.open(download_url, '_blank');
       if (printWindow) {
         printWindow.onload = () => {
@@ -154,11 +154,11 @@ const CompletedEnvelopes = () => {
     }
   };
 
-  const handleDelete = async (id) => {
+  const handleDelete = async (publicId) => {
     try {
-      await signatureService.cancelEnvelope(id);
-      setEnvelopes(prev => prev.filter(env => env.id !== id));
-      setFilteredEnvelopes(prev => prev.filter(env => env.id !== id));
+      await signatureService.cancelEnvelope(publicId);
+      setEnvelopes(prev => prev.filter(env => env.public_id !== publicId));
+      setFilteredEnvelopes(prev => prev.filter(env => env.public_id !== publicId));
       setMenuOpenId(null);
       toast.success('Enveloppe supprimée avec succès');
     } catch (err) {
@@ -205,11 +205,11 @@ const CompletedEnvelopes = () => {
             <button
               onClick={e => {
                 e.stopPropagation();
-                if (menuOpenId === envelope.id) {
+                if (menuOpenId === envelope.public_id) {
                   closeMenu();
                 } else {
                   menuButtonRef.current = e.currentTarget;
-                  setMenuOpenId(envelope.id);
+                  setMenuOpenId(envelope.public_id);
                 }
               }}
               className="p-2 hover:bg-gray-100 rounded-full transition-colors"
@@ -217,13 +217,13 @@ const CompletedEnvelopes = () => {
               <FiMoreVertical className="w-4 h-4 text-gray-500" />
             </button>
             
-            {menuOpenId === envelope.id && (
+            {menuOpenId === envelope.public_id && (
               <div className="absolute right-0 top-full mt-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-20">
                 <div className="py-1">
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      handlePreview(envelope.id);
+                      handlePreview(envelope.public_id);
                       closeMenu();
                     }}
                     className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
@@ -234,7 +234,7 @@ const CompletedEnvelopes = () => {
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      handleDownload(envelope.id, envelope.title);
+                      handleDownload(envelope.public_id, envelope.title);
                       closeMenu();
                     }}
                     className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
@@ -245,7 +245,7 @@ const CompletedEnvelopes = () => {
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      handlePrint(envelope.id);
+                      handlePrint(envelope.public_id);
                       closeMenu();
                     }}
                     className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
@@ -257,7 +257,7 @@ const CompletedEnvelopes = () => {
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      setConfirmId(envelope.id);
+                      setConfirmId(envelope.public_id);
                       closeMenu();
                     }}
                     className="flex items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50"
@@ -342,29 +342,29 @@ const CompletedEnvelopes = () => {
     );
   };
 
-  const ActionsCell = ({ value: id, row }) => (
+  const ActionsCell = ({ value: publicId, row }) => (
     <div className="relative inline-block">
       <button
         onClick={e => {
           e.stopPropagation();
-          if (menuOpenId === id) {
+          if (menuOpenId === publicId) {
             closeMenu();
           } else {
             menuButtonRef.current = e.currentTarget;
-            setMenuOpenId(id);
+            setMenuOpenId(publicId);
           }
         }}
         className="p-2 hover:bg-gray-100 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
       >
         <FiMoreVertical className="w-5 h-5 text-gray-600" />
       </button>
-      {menuOpenId === id && (
+      {menuOpenId === publicId && (
         <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
           <div className="py-1">
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                handlePreview(id);
+                handlePreview(publicId);
                 closeMenu();
               }}
               className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
@@ -375,7 +375,7 @@ const CompletedEnvelopes = () => {
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                handleDownload(id, row.title);
+                handleDownload(publicId, row.title);
                 closeMenu();
               }}
               className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
@@ -386,7 +386,7 @@ const CompletedEnvelopes = () => {
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                handlePrint(id);
+                handlePrint(publicId);
                 closeMenu();
               }}
               className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
@@ -398,7 +398,7 @@ const CompletedEnvelopes = () => {
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                setConfirmId(id);
+                setConfirmId(publicId);
                 closeMenu();
               }}
               className="flex items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
@@ -433,7 +433,7 @@ const CompletedEnvelopes = () => {
     },
     {
       Header: 'Actions',
-      accessor: 'id',
+      accessor: 'public_id',
       Cell: ActionsCell,
       cellClassName: 'text-right whitespace-nowrap'
     }
@@ -570,7 +570,7 @@ const CompletedEnvelopes = () => {
             /* Mobile: Cards Layout */
             <div className="space-y-4">
               {filteredEnvelopes.map((envelope) => (
-                <MobileCard key={envelope.id} envelope={envelope} />
+                <MobileCard key={envelope.public_id} envelope={envelope} />
               ))}
             </div>
           ) : (

--- a/frontend/src/components/DeletedEnvelopes.js
+++ b/frontend/src/components/DeletedEnvelopes.js
@@ -49,32 +49,32 @@ const DeletedEnvelopes = () => {
     loadEnvelopes();
   }, []);
 
-  const handlePreview = id => {
-    if (!id) return;
-    navigate(`/signature/detail/${id}`);
+  const handlePreview = publicId => {
+    if (!publicId) return;
+    navigate(`/signature/detail/${publicId}`);
   };
 
-  const handleRestore = async id => {
-    if (!id) return;
+  const handleRestore = async publicId => {
+    if (!publicId) return;
     try {
-      await signatureService.restoreEnvelope(id);
+      await signatureService.restoreEnvelope(publicId);
       toast.success("Enveloppe restaurée avec succès");
-      setEnvelopes(prev => prev.filter(env => env.id !== id));
+      setEnvelopes(prev => prev.filter(env => env.public_id !== publicId));
     } catch (err) {
       toast.error("Échec de la restauration de l'enveloppe");
       logService.error('Failed to restore envelope:', err);
     }
   };
 
-  const handlePurge = async id => {
-    if (!id) {
+  const handlePurge = async publicId => {
+    if (!publicId) {
       setConfirmId(null);
       return;
     }
     try {
-      await signatureService.purgeEnvelope(id);
+      await signatureService.purgeEnvelope(publicId);
       toast.success("Enveloppe purgée définitivement");
-      setEnvelopes(prev => prev.filter(env => env.id !== id));
+      setEnvelopes(prev => prev.filter(env => env.public_id !== publicId));
     } catch (err) {
       toast.error("Échec de la purge de l'enveloppe");
       logService.error('Failed to purge envelope:', err);
@@ -90,11 +90,11 @@ const DeletedEnvelopes = () => {
     </div>
   );
 
-  const ActionsCell = ({ value }) => (
+  const ActionsCell = ({ value: publicId }) => (
     <div className="flex items-center justify-end gap-2">
       <button
         type="button"
-        onClick={() => handlePreview(value)}
+        onClick={() => handlePreview(publicId)}
         className="p-2 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded-full transition"
         title="Prévisualiser"
       >
@@ -102,7 +102,7 @@ const DeletedEnvelopes = () => {
       </button>
       <button
         type="button"
-        onClick={() => handleRestore(value)}
+        onClick={() => handleRestore(publicId)}
         className="p-2 text-gray-500 hover:text-green-600 hover:bg-green-50 rounded-full transition"
         title="Restaurer"
       >
@@ -110,7 +110,7 @@ const DeletedEnvelopes = () => {
       </button>
       <button
         type="button"
-        onClick={() => setConfirmId(value)}
+        onClick={() => setConfirmId(publicId)}
         className="p-2 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-full transition"
         title="Purger définitivement"
       >
@@ -173,7 +173,7 @@ const DeletedEnvelopes = () => {
     },
     {
       Header: 'Actions',
-      accessor: 'id',
+      accessor: 'public_id',
       Cell: ActionsCell,
       headerClassName: 'text-right w-32',
       cellClassName: 'text-right'

--- a/frontend/src/components/DraftEnvelopes.js
+++ b/frontend/src/components/DraftEnvelopes.js
@@ -31,15 +31,15 @@ const DraftEnvelopes = () => {
     loadEnvelopes();
   }, []);
 
-  const handleEditDraft = (id) => {
-    navigate(`/signature/workflow/${id}`);
+  const handleEditDraft = (publicId) => {
+    navigate(`/signature/workflow/${publicId}`);
   };
 
   const confirmDeleteDraft = async () => {
     if (confirmId === null) return;
     try {
       await signatureService.cancelEnvelope(confirmId);
-      setEnvelopes(prev => prev.filter(env => env.id !== confirmId));
+      setEnvelopes(prev => prev.filter(env => env.public_id !== confirmId));
       toast.success('Brouillon supprimé');
     } catch (err) {
       toast.error('Échec de la suppression');
@@ -56,17 +56,17 @@ const DraftEnvelopes = () => {
     </div>
   );
 
-  const ActionsCell = ({ value: id }) => (
+  const ActionsCell = ({ value: publicId }) => (
     <div className="flex space-x-2">
       <button
-        onClick={() => handleEditDraft(id)}
+        onClick={() => handleEditDraft(publicId)}
         className="text-blue-600 hover:text-blue-800 p-1"
         title="Modifier"
       >
         <FiEdit2 className="w-5 h-5" />
       </button>
       <button
-        onClick={() => setConfirmId(id)}
+        onClick={() => setConfirmId(publicId)}
         className="text-red-600 hover:text-red-800 hover:bg-red-50 p-1 rounded"
         title="Supprimer"
       >
@@ -92,7 +92,7 @@ const DraftEnvelopes = () => {
     },
     {
       Header: 'Actions',
-      accessor: 'id',
+      accessor: 'public_id',
       Cell: ActionsCell
     }
   ];

--- a/frontend/src/components/SentEnvelopes.js
+++ b/frontend/src/components/SentEnvelopes.js
@@ -40,11 +40,11 @@ const SentEnvelopes = () => {
     };
   }, []);
 
-  const handleCancel = async (id) => {
+  const handleCancel = async (publicId) => {
     try {
-      await signatureService.cancelEnvelope(id);
+      await signatureService.cancelEnvelope(publicId);
       toast.success('Enveloppe annulée');
-      setEnvelopes((prev) => prev.filter((e) => e.id !== id));
+      setEnvelopes((prev) => prev.filter((e) => e.public_id !== publicId));
     } catch (err) {
       toast.error("Échec de l'annulation");
       logService?.error?.(err);
@@ -107,16 +107,16 @@ const SentEnvelopes = () => {
   }, []);
 
   const ActionsCell = useCallback(
-    ({ value }) => (
+    ({ value: publicId }) => (
       <div className="flex flex-wrap gap-2">
         <Link
-          to={`/signature/detail/${value}`}
+          to={`/signature/detail/${publicId}`}
           className="text-blue-600 hover:text-blue-800 text-sm"
         >
           Détails
         </Link>
         <button
-          onClick={() => setConfirmId(value)}
+          onClick={() => setConfirmId(publicId)}
           className="text-red-600 hover:text-red-800 text-sm"
         >
           Annuler
@@ -150,7 +150,7 @@ const SentEnvelopes = () => {
       },
       {
         Header: 'Actions',
-        accessor: 'id',
+        accessor: 'public_id',
         Cell: ActionsCell,
         headerClassName: 'text-right',
         cellClassName: 'text-right',

--- a/frontend/src/pages/DashboardSignature.js
+++ b/frontend/src/pages/DashboardSignature.js
@@ -103,13 +103,13 @@ const DashboardSignature = () => {
 
     const notifs = completed
       .slice(-5)
-      .map(e => ({ id: e.id, title: e.title, type: 'normal', time: e.updated_at }));
+      .map(e => ({ id: e.public_id, title: e.title, type: 'normal', time: e.updated_at }));
 
     const recents = filtered
       .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
       .slice(0, 5)
       .map(e => ({
-        id: e.id,
+        publicId: e.public_id,
         title: e.title,
         status: e.status === 'action_required' ? 'actionRequired' : e.status,
         progress: (
@@ -160,10 +160,10 @@ const DashboardSignature = () => {
   }, [allEnvelopes, actionEnvelopes, dateFilter, customRange]);
 
   // Preview decrypted PDF in a new tab
-  const handlePreview = async (id) => {
-    setPreviewLoadingId(id);
+  const handlePreview = async (publicId) => {
+    setPreviewLoadingId(publicId);
     try {
-      const { download_url } = await signatureService.downloadEnvelope(id);
+      const { download_url } = await signatureService.downloadEnvelope(publicId);
       window.open(download_url, '_blank');
     } catch (error) {
       logService.error('Erreur lors de la prévisualisation du PDF:', error);
@@ -174,9 +174,9 @@ const DashboardSignature = () => {
   };
 
   // Download decrypted PDF with proper filename
-  const handleDownload = async (id, title) => {
+  const handleDownload = async (publicId, title) => {
     try {
-      const { download_url } = await signatureService.downloadEnvelope(id);
+      const { download_url } = await signatureService.downloadEnvelope(publicId);
       const response = await fetch(download_url);
       const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
@@ -199,12 +199,12 @@ const DashboardSignature = () => {
     }
   };
 
-  const toggleCardExpansion = (id) => {
+  const toggleCardExpansion = (publicId) => {
     const newExpanded = new Set(expandedCards);
-    if (newExpanded.has(id)) {
-      newExpanded.delete(id);
+    if (newExpanded.has(publicId)) {
+      newExpanded.delete(publicId);
     } else {
-      newExpanded.add(id);
+      newExpanded.add(publicId);
     }
     setExpandedCards(newExpanded);
   };
@@ -481,7 +481,7 @@ const DashboardSignature = () => {
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
                       {displayedDocuments.map(doc => (
-                        <tr key={doc.id} className="hover:bg-gray-50 transition-colors duration-150">
+                        <tr key={doc.publicId} className="hover:bg-gray-50 transition-colors duration-150">
                           <td className="px-4 lg:px-6 py-4">
                             <p className="text-sm font-medium text-gray-900 max-w-xs truncate" title={doc.title}>
                               {doc.title}
@@ -537,15 +537,15 @@ const DashboardSignature = () => {
                           <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-right">
                             <div className="flex items-center justify-end space-x-2">
                               <button
-                                onClick={() => handlePreview(doc.id)}
-                                disabled={previewLoadingId === doc.id}
-                                className={`p-1 text-gray-400 ${previewLoadingId === doc.id ? 'opacity-50 cursor-not-allowed' : 'hover:text-blue-600'} transition-colors duration-200`}
+                                onClick={() => handlePreview(doc.publicId)}
+                                disabled={previewLoadingId === doc.publicId}
+                                className={`p-1 text-gray-400 ${previewLoadingId === doc.publicId ? 'opacity-50 cursor-not-allowed' : 'hover:text-blue-600'} transition-colors duration-200`}
                                 title="Prévisualiser"
                               >
                                 <Eye className="w-4 h-4" />
                               </button>
                               <button
-                                onClick={() => handleDownload(doc.id, doc.title)}
+                                onClick={() => handleDownload(doc.publicId, doc.title)}
                                 className="p-1 text-gray-400 hover:text-green-600 transition-colors duration-200"
                                 title="Télécharger"
                               >
@@ -570,7 +570,7 @@ const DashboardSignature = () => {
               <div className="block md:hidden">
                 <div className="divide-y divide-gray-200">
                   {displayedDocuments.map(doc => (
-                    <div key={doc.id} className="p-4 hover:bg-gray-50 transition-colors duration-200">
+                    <div key={doc.publicId} className="p-4 hover:bg-gray-50 transition-colors duration-200">
                       {/* En-tête de la carte */}
                       <div className="flex items-start justify-between mb-3">
                         <div className="flex-1 min-w-0 pr-2">
@@ -582,12 +582,12 @@ const DashboardSignature = () => {
                         
                         {/* Bouton d'expansion */}
                         <button
-                          onClick={() => toggleCardExpansion(doc.id)}
+                          onClick={() => toggleCardExpansion(doc.publicId)}
                           className="p-1 text-gray-400 hover:text-gray-600 transition-colors duration-200"
-                          title={expandedCards.has(doc.id) ? "Réduire" : "Développer"}
+                          title={expandedCards.has(doc.publicId) ? "Réduire" : "Développer"}
                         >
-                          <ChevronDown 
-                            className={`w-5 h-5 transition-transform duration-200 ${expandedCards.has(doc.id) ? 'rotate-180' : ''}`} 
+                          <ChevronDown
+                            className={`w-5 h-5 transition-transform duration-200 ${expandedCards.has(doc.publicId) ? 'rotate-180' : ''}`}
                           />
                         </button>
                       </div>
@@ -614,7 +614,7 @@ const DashboardSignature = () => {
                       </div>
 
                       {/* Informations supplémentaires - conditionnellement visibles */}
-                      <div className={`transition-all duration-300 overflow-hidden ${expandedCards.has(doc.id) ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}>
+                      <div className={`transition-all duration-300 overflow-hidden ${expandedCards.has(doc.publicId) ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}>
                         <div className="space-y-3 pt-3 border-t border-gray-100">
                           {/* Métadonnées */}
                           <div className="grid grid-cols-1 gap-2 text-xs text-gray-500">
@@ -643,11 +643,11 @@ const DashboardSignature = () => {
                           {/* Actions */}
                           <div className="flex items-center justify-end space-x-3 pt-2">
                             <button
-                              onClick={() => handlePreview(doc.id)}
-                              disabled={previewLoadingId === doc.id}
+                              onClick={() => handlePreview(doc.publicId)}
+                              disabled={previewLoadingId === doc.publicId}
                               className={`flex items-center space-x-1 px-3 py-2 text-xs font-medium rounded-md transition-colors duration-200 ${
-                                previewLoadingId === doc.id 
-                                  ? 'bg-gray-100 text-gray-400 cursor-not-allowed' 
+                                previewLoadingId === doc.publicId
+                                  ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
                                   : 'bg-blue-50 text-blue-600 hover:bg-blue-100'
                               }`}
                               title="Prévisualiser"
@@ -656,7 +656,7 @@ const DashboardSignature = () => {
                               <span>Voir</span>
                             </button>
                             <button
-                              onClick={() => handleDownload(doc.id, doc.title)}
+                              onClick={() => handleDownload(doc.publicId, doc.title)}
                               className="flex items-center space-x-1 px-3 py-2 text-xs font-medium text-green-600 bg-green-50 rounded-md hover:bg-green-100 transition-colors duration-200"
                               title="Télécharger"
                             >
@@ -675,17 +675,17 @@ const DashboardSignature = () => {
                       </div>
 
                       {/* Actions rapides - toujours visibles en mode compact */}
-                      <div className={`flex items-center justify-end space-x-2 mt-3 ${expandedCards.has(doc.id) ? 'hidden' : 'flex'}`}>
+                      <div className={`flex items-center justify-end space-x-2 mt-3 ${expandedCards.has(doc.publicId) ? 'hidden' : 'flex'}`}>
                         <button
-                          onClick={() => handlePreview(doc.id)}
-                          disabled={previewLoadingId === doc.id}
-                          className={`p-2 text-gray-400 ${previewLoadingId === doc.id ? 'opacity-50 cursor-not-allowed' : 'hover:text-blue-600'} transition-colors duration-200`}
+                          onClick={() => handlePreview(doc.publicId)}
+                          disabled={previewLoadingId === doc.publicId}
+                          className={`p-2 text-gray-400 ${previewLoadingId === doc.publicId ? 'opacity-50 cursor-not-allowed' : 'hover:text-blue-600'} transition-colors duration-200`}
                           title="Prévisualiser"
                         >
                           <Eye className="w-5 h-5" />
                         </button>
                         <button
-                          onClick={() => handleDownload(doc.id, doc.title)}
+                          onClick={() => handleDownload(doc.publicId, doc.title)}
                           className="p-2 text-gray-400 hover:text-green-600 transition-colors duration-200"
                           title="Télécharger"
                         >

--- a/frontend/src/pages/DocumentDetail.js
+++ b/frontend/src/pages/DocumentDetail.js
@@ -82,7 +82,7 @@ function ReminderModal({ open, count, onClose }) {
 }
 
 const DocumentDetail = () => {
-  const { id } = useParams();
+  const { publicId } = useParams();
   const navigate = useNavigate();
 
   // État principal
@@ -192,7 +192,7 @@ const DocumentDetail = () => {
   const loadConsolidatedPreview = useCallback(async () => {
     setLoadingPdf(true);
     try {
-      const { download_url } = await signatureService.downloadEnvelope(id);
+      const { download_url } = await signatureService.downloadEnvelope(publicId);
       setPdfUrl(prev => {
         if (prev && prev.startsWith('blob:')) URL.revokeObjectURL(prev);
         return download_url;
@@ -207,10 +207,10 @@ const DocumentDetail = () => {
     } finally {
       setLoadingPdf(false);
     }
-  }, [id]);
+  }, [publicId]);
 
   const fetchEnvelope = useCallback(async () => {
-    const data = await signatureService.getEnvelope(id);
+    const data = await signatureService.getEnvelope(publicId);
     setEnv(data);
     const docs = data.documents || [];
     setDocuments(docs);
@@ -226,7 +226,7 @@ const DocumentDetail = () => {
       await loadConsolidatedPreview();
     }
     return data;
-  }, [id, isMobile, loadConsolidatedPreview]);
+  }, [publicId, isMobile, loadConsolidatedPreview]);
 
   // Chargement initial
   useEffect(() => {
@@ -261,7 +261,7 @@ const DocumentDetail = () => {
       let filename = env ? `${env.title}.pdf` : 'document.pdf';
 
       if (!blobHref) {
-        const { download_url } = await signatureService.downloadEnvelope(env.id);
+        const { download_url } = await signatureService.downloadEnvelope(env.public_id);
         blobHref = download_url;
       } else if (env?.status === 'completed') {
         filename = `${env.title}_signed.pdf`;
@@ -288,7 +288,7 @@ const DocumentDetail = () => {
   const handleRemind = async () => {
     setReminding(true);
     try {
-      const { reminders } = await signatureService.remindNow(env.id);
+      const { reminders } = await signatureService.remindNow(env.public_id);
       const n = reminders ?? 0;
       setReminderCount(n);
       setReminderModalOpen(true);
@@ -301,10 +301,10 @@ const DocumentDetail = () => {
   };
 
   const handleRestore = async () => {
-    if (!env?.id || restoring) return;
+    if (!env?.public_id || restoring) return;
     setRestoring(true);
     try {
-      await signatureService.restoreEnvelope(env.id);
+      await signatureService.restoreEnvelope(env.public_id);
       toast.success('Enveloppe restaurée avec succès');
       try {
         await fetchEnvelope();
@@ -322,13 +322,13 @@ const DocumentDetail = () => {
 
   const handlePurge = async () => {
     if (purging) return;
-    if (!env?.id) {
+    if (!env?.public_id) {
       setConfirmOpen(false);
       return;
     }
     setPurging(true);
     try {
-      await signatureService.purgeEnvelope(env.id);
+      await signatureService.purgeEnvelope(env.public_id);
       toast.success('Enveloppe purgée définitivement');
       navigate('/signature/envelopes/deleted');
     } catch (err) {
@@ -673,7 +673,7 @@ const DocumentDetail = () => {
                 style={{ touchAction: 'none' }}
               >
                 <Document
-                  key={env?.status === 'completed' ? `signed-${env.id}` : `orig-${env.id}-${selectedDoc?.id || 'single'}`}
+                  key={env?.status === 'completed' ? `signed-${env?.public_id}` : `orig-${env?.public_id}-${selectedDoc?.id || 'single'}`}
                   file={pdfUrl}
                   onLoadSuccess={onDocumentLoad}
                   onLoadError={onDocumentError}

--- a/frontend/src/pages/DocumentDetail.test.js
+++ b/frontend/src/pages/DocumentDetail.test.js
@@ -35,12 +35,13 @@ jest.mock('react-toastify', () => ({
 
 jest.mock('react-router-dom', () => ({
   Link: ({ children, ...props }) => <a {...props}>{children}</a>,
-  useParams: () => ({ id: '123' }),
+  useParams: () => ({ publicId: '123' }),
   useNavigate: () => mockNavigate
 }));
 
 const cancelledEnvelope = {
   id: '123',
+  public_id: '123',
   title: 'Annulée',
   status: 'cancelled',
   version: 1,

--- a/frontend/src/pages/DocumentUpload.js
+++ b/frontend/src/pages/DocumentUpload.js
@@ -69,7 +69,7 @@ const DocumentUpload = () => {
     try {
       const response = await signatureService.createEnvelope(formData);
       toast.success('Document téléversé avec succès');
-      navigate(`/signature/workflow/${response.id}`);
+      navigate(`/signature/workflow/${response.public_id}`);
     } catch (error) {
       logService.error('Erreur lors du téléversement:', error);
       toast.error(error.response?.data?.detail || 'Erreur lors du téléversement du document');

--- a/frontend/src/pages/DocumentWorkflow.js
+++ b/frontend/src/pages/DocumentWorkflow.js
@@ -593,7 +593,7 @@ const formatShortDate = (isoString) => {
    COMPOSANT PRINCIPAL
    ========================= */
 export default function DocumentWorkflow() {
-  const { id } = useParams();
+  const { publicId } = useParams();
   const navigate = useNavigate();
   const [envelope, setEnvelope] = useState(null);
   const [flowType, setFlowType] = useState('sequential');
@@ -698,7 +698,7 @@ export default function DocumentWorkflow() {
   const uploadFiles = useCallback(async (files) => {
     try {
       setIsUploading(true);
-      await signatureService.updateEnvelopeFiles(id, files);
+      await signatureService.updateEnvelopeFiles(publicId, files);
       toast.success('Fichiers ajoutés');
       await reloadEnvelope();
     } catch (e) {
@@ -707,10 +707,10 @@ export default function DocumentWorkflow() {
     } finally {
       setIsUploading(false);
     }
-  }, [id]);
+  }, [publicId, reloadEnvelope]);
 
   const reloadEnvelope = useCallback(async () => {
-    const env = await signatureService.getEnvelope(id);
+    const env = await signatureService.getEnvelope(publicId);
     setEnvelope(env);
     setFlowType(env.flow_type || 'sequential');
     setReminderDays(env.reminder_days ?? 1);
@@ -732,17 +732,17 @@ export default function DocumentWorkflow() {
       const first = docs[0];
       if (stableSelectedDocId.current !== first.id) {
         setSelectedDocId(first.id);
-        const blobUrl = await signatureService.fetchDocumentBlob(id, first.id);
+        const blobUrl = await signatureService.fetchDocumentBlob(publicId, first.id);
         setPdfUrl(blobUrl);
       }
     } else {
-      const res = await signatureService.downloadEnvelope(id);
+      const res = await signatureService.downloadEnvelope(publicId);
       if (stableSelectedDocId.current !== 'single') {
         setSelectedDocId('single');
         setPdfUrl(res.download_url);
       }
     }
-  }, [id]);
+  }, [publicId]);
 
   useEffect(() => {
     (async () => {
@@ -752,7 +752,7 @@ export default function DocumentWorkflow() {
         toast.error('Impossible de charger le dossier');
       }
     })();
-  }, [id, reloadEnvelope]);
+  }, [publicId, reloadEnvelope]);
 
   // Largeur PDF
   useEffect(() => {
@@ -819,7 +819,7 @@ export default function DocumentWorkflow() {
     let cancelled = false;
     setLoadingDocId(doc.id);
     try {
-      const blobUrl = await signatureService.fetchDocumentBlob(id, doc.id);
+      const blobUrl = await signatureService.fetchDocumentBlob(publicId, doc.id);
       if (cancelled) return;
       setPdfUrl(blobUrl);
       setSelectedDocId(doc.id);
@@ -942,19 +942,19 @@ export default function DocumentWorkflow() {
         toast.error("L'échéance est déjà passée");
         return;
       }
-      await signatureService.updateEnvelope(id, payload);
-      await signatureService.sendEnvelope(id, {
+      await signatureService.updateEnvelope(publicId, payload);
+      await signatureService.sendEnvelope(publicId, {
         include_qr_code: includeQr,
         reminder_days: payload.reminder_days,
         deadline_at: payload.deadline_at,
       });
       toast.success('Enveloppe envoyée');
-      navigate(`/signature/sent/${id}`);
+      navigate(`/signature/sent/${publicId}`);
     } catch (err) {
       logService.error(err);
       toast.error("Échec de l'envoi");
     }
-  }, [id, recipients, fields, flowType, includeQr, reminderDays, deadlineAt, navigate]);
+  }, [publicId, recipients, fields, flowType, includeQr, reminderDays, deadlineAt, navigate]);
 
   const hasSignatureOnDoc = useCallback((recipientOrder) =>
     fields.some((f) => f.recipient_id === recipientOrder && f.document_id === selectedDocId && f.field_type === 'signature'),

--- a/frontend/src/pages/EnvelopeSent.js
+++ b/frontend/src/pages/EnvelopeSent.js
@@ -18,7 +18,7 @@ import {
 import logService from '../services/logService';
 import sanitize from '../utils/sanitize';
 export default function EnvelopeSent() {
-  const { id } = useParams();
+  const { publicId } = useParams();
   const navigate = useNavigate();
   const [envelope, setEnvelope] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -27,7 +27,7 @@ export default function EnvelopeSent() {
     const loadEnvelope = async () => {
       try {
         setLoading(true);
-        const data = await signatureService.getEnvelope(id);
+        const data = await signatureService.getEnvelope(publicId);
         setEnvelope(data);
       } catch (error) {
         logService.error("Erreur lors du chargement de l'enveloppe:", error);
@@ -36,8 +36,8 @@ export default function EnvelopeSent() {
         setLoading(false);
       }
     };
-    if (id) loadEnvelope();
-  }, [id]);
+    if (publicId) loadEnvelope();
+  }, [publicId]);
 
   if (loading) {
     return (
@@ -280,7 +280,7 @@ export default function EnvelopeSent() {
             <h3 className="text-lg font-medium text-gray-900 mb-4">Actions disponibles</h3>
             <div className="flex flex-col sm:flex-row gap-3">
               <button
-                onClick={() => navigate(`/signature/detail/${id}`)}
+                onClick={() => navigate(`/signature/detail/${publicId}`)}
                 className="inline-flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
                 <Eye className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- update signature routes to use the publicId parameter for document detail, workflow and sent views
- migrate envelope listing components and the dashboard to build links, filters and service calls from envelope.public_id values
- adapt upload, workflow and detail pages plus the associated unit test to rely on publicId/public_id identifiers throughout

## Testing
- npm test -- DocumentDetail.test.js *(fails: react-scripts missing because dependencies could not be installed without native pixman)*
- npm run lint *(fails: npm script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7ff1f3b083338e9f6fe68530f5d2