### PR TITLE
Prevent purging non-cancelled envelopes

### DIFF
--- a/backend/signature/tests/test_envelope_actions.py
+++ b/backend/signature/tests/test_envelope_actions.py
@@ -278,6 +278,23 @@ class EnvelopeActionTests(APITestCase):
         self.assertFalse(doc_storage.exists(doc_path))
         self.assertFalse(signed_storage.exists(signed_path))
 
+    def test_purge_requires_cancelled_status(self):
+        envelope = Envelope.objects.create(
+            title="Doc",
+            created_by=self.creator,
+            status="sent",
+        )
+
+        url = reverse("envelopes-purge", kwargs={"pk": envelope.pk})
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["detail"],
+            "Seules les enveloppes annulées peuvent être purgées.",
+        )
+        self.assertTrue(Envelope.objects.filter(pk=envelope.pk).exists())
+
     def test_purge_forbidden_for_non_creator(self):
         envelope = Envelope.objects.create(
             title="Doc",

--- a/backend/signature/views/envelope.py
+++ b/backend/signature/views/envelope.py
@@ -492,6 +492,13 @@ class EnvelopeViewSet(viewsets.ModelViewSet):
         permission_error = self._ensure_creator(request, envelope)
         if permission_error:
             return permission_error
+        if envelope.status != "cancelled":
+            return Response(
+                {
+                    "detail": "Seules les enveloppes annulées peuvent être purgées."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         self._delete_envelope_files(envelope)
         envelope.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/frontend/src/components/DeletedEnvelopes.js
+++ b/frontend/src/components/DeletedEnvelopes.js
@@ -76,7 +76,8 @@ const DeletedEnvelopes = () => {
       toast.success("Enveloppe purgée définitivement");
       setEnvelopes(prev => prev.filter(env => env.public_id !== publicId));
     } catch (err) {
-      toast.error("Échec de la purge de l'enveloppe");
+      const message = err?.message || "Échec de la purge de l'enveloppe";
+      toast.error(message);
       logService.error('Failed to purge envelope:', err);
     } finally {
       setConfirmId(null);

--- a/frontend/src/pages/DocumentDetail.js
+++ b/frontend/src/pages/DocumentDetail.js
@@ -332,7 +332,8 @@ const DocumentDetail = () => {
       toast.success('Enveloppe purgée définitivement');
       navigate('/signature/envelopes/deleted');
     } catch (err) {
-      toast.error("Échec de la purge de l'enveloppe");
+      const message = err?.message || "Échec de la purge de l'enveloppe";
+      toast.error(message);
       logService.error('Failed to purge envelope:', err);
     } finally {
       setPurging(false);


### PR DESCRIPTION
## Summary
- forbid purging envelopes that are not in the cancelled state by returning a 400 response with a descriptive message
- cover the purge failure path for active envelopes with a new unit test
- surface backend error messages in purge toasts on the document detail and deleted envelopes views

## Testing
- python manage.py test signature.tests.test_envelope_actions

------
https://chatgpt.com/codex/tasks/task_e_68cdb7c793208333b968ca9b50a056b6