### PR TITLE
Normalize saved signature preview URLs

### DIFF
--- a/frontend/src/pages/SavedSignaturesPage.js
+++ b/frontend/src/pages/SavedSignaturesPage.js
@@ -137,23 +137,27 @@ const SavedSignaturesPage = () => {
         <h2 className="font-medium mb-2">Signatures existantes</h2>
         {items.length === 0 && <p>Aucune signature enregistrée.</p>}
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {items.map(sig => (
-            <div key={sig.id} className="border p-2 rounded relative">
-              <img
-  src={sig.data_url || sig.image_url}
-  alt={sig.kind || 'signature'}
-  style={{ maxHeight: 80 }}
-/>
+          {items.map(sig => {
+            const imageSrc = sig.data_url || toAbsolute(sig.image_url);
+            return (
+              <div key={sig.id} className="border p-2 rounded relative">
+                {imageSrc ? (
+                  <img src={imageSrc} alt={sig.kind || 'signature'} style={{ maxHeight: 80 }} />
+                ) : (
+                  <div className="h-20 flex items-center justify-center text-sm text-gray-500 bg-gray-100 rounded">
+                    Aucune image
+                  </div>
+                )}
 
-
-              <button
-                onClick={() => remove(sig.id)}
-                className="absolute top-1 right-1 text-red-600"
-              >
-                ×
-              </button>
-            </div>
-          ))}
+                <button
+                  onClick={() => remove(sig.id)}
+                  className="absolute top-1 right-1 text-red-600"
+                >
+                  ×
+                </button>
+              </div>
+            );
+          })}
         </div>
       </div>
       <ConfirmDialog


### PR DESCRIPTION
## Summary
- normalize saved signature thumbnail URLs with `toAbsolute`
- avoid rendering broken images by showing a placeholder when no source is available

## Testing
- npm install *(fails: canvas native dependency requires pixman-1 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f061cdc483339d3522afa98e7576